### PR TITLE
Add placeholder forms for cocktails and ingredients

### DIFF
--- a/app/(tabs)/cocktails/_layout.tsx
+++ b/app/(tabs)/cocktails/_layout.tsx
@@ -1,4 +1,5 @@
 import { withLayoutContext } from 'expo-router';
+// eslint-disable-next-line import/no-unresolved
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React from 'react';
 

--- a/app/(tabs)/cocktails/all.tsx
+++ b/app/(tabs)/cocktails/all.tsx
@@ -1,12 +1,14 @@
 import { Button } from 'react-native';
+import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 
 export default function AllCocktailsScreen() {
+  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
       <ThemedText type="title">All Cocktails</ThemedText>
-      <Button title="Add" onPress={() => {}} />
+      <Button title="Add" onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/cocktails/favorites.tsx
+++ b/app/(tabs)/cocktails/favorites.tsx
@@ -1,12 +1,14 @@
 import { Button } from 'react-native';
+import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 
 export default function FavoriteCocktailsScreen() {
+  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
       <ThemedText type="title">Favorite Cocktails</ThemedText>
-      <Button title="Add" onPress={() => {}} />
+      <Button title="Add" onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/cocktails/my.tsx
+++ b/app/(tabs)/cocktails/my.tsx
@@ -1,12 +1,14 @@
 import { Button } from 'react-native';
+import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 
 export default function MyCocktailsScreen() {
+  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
       <ThemedText type="title">My Cocktails</ThemedText>
-      <Button title="Add" onPress={() => {}} />
+      <Button title="Add" onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/ingredients/_layout.tsx
+++ b/app/(tabs)/ingredients/_layout.tsx
@@ -1,4 +1,5 @@
 import { withLayoutContext } from 'expo-router';
+// eslint-disable-next-line import/no-unresolved
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React from 'react';
 

--- a/app/(tabs)/ingredients/all.tsx
+++ b/app/(tabs)/ingredients/all.tsx
@@ -1,12 +1,14 @@
 import { Button } from 'react-native';
+import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 
 export default function AllIngredientsScreen() {
+  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
       <ThemedText type="title">All Ingredients</ThemedText>
-      <Button title="Add" onPress={() => {}} />
+      <Button title="Add" onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/ingredients/my.tsx
+++ b/app/(tabs)/ingredients/my.tsx
@@ -1,12 +1,14 @@
 import { Button } from 'react-native';
+import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 
 export default function MyIngredientsScreen() {
+  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
       <ThemedText type="title">My Ingredients</ThemedText>
-      <Button title="Add" onPress={() => {}} />
+      <Button title="Add" onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/ingredients/shopping.tsx
+++ b/app/(tabs)/ingredients/shopping.tsx
@@ -1,12 +1,14 @@
 import { Button } from 'react-native';
+import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 
 export default function ShoppingIngredientsScreen() {
+  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
       <ThemedText type="title">Shopping List</ThemedText>
-      <Button title="Add" onPress={() => {}} />
+      <Button title="Add" onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }

--- a/app/add-cocktail.tsx
+++ b/app/add-cocktail.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function AddCocktailScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      <ThemedText type="title">Add Cocktail</ThemedText>
+    </ThemedView>
+  );
+}

--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -1,0 +1,10 @@
+import { ThemedView } from '@/components/ThemedView';
+import { ThemedText } from '@/components/ThemedText';
+
+export default function AddIngredientScreen() {
+  return (
+    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      <ThemedText type="title">Add Ingredient</ThemedText>
+    </ThemedView>
+  );
+}


### PR DESCRIPTION
## Summary
- link Add buttons on cocktail and ingredient tabs to new add-cocktail and add-ingredient routes
- scaffold placeholder screens for adding cocktails and ingredients
- silence lint errors for material top tab navigator imports

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae3d6abc58832685a9af4e9d467b43