### PR TITLE
feat: add general menu above tabs

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,9 +1,10 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
-import { Platform } from 'react-native';
+import { Platform, View } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 import { HapticTab } from '@/components/HapticTab';
+import GeneralMenu from '@/components/GeneralMenu';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -12,47 +13,50 @@ export default function TabLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <Tabs
-      screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
-        headerShown: false,
-        tabBarButton: HapticTab,
-        tabBarBackground: TabBarBackground,
-        tabBarStyle: Platform.select({
-          ios: {
-            // Use a transparent background on iOS to show the blur effect
-            position: 'absolute',
-          },
-          default: {},
-        }),
-      }}>
-      <Tabs.Screen
-        name="cocktails"
-        options={{
-          title: 'Cocktails',
-          tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} name="local-bar" color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="shaker"
-        options={{
-          title: 'Shaker',
-          tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} name="science" color={color} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="ingredients"
-        options={{
-          title: 'Ingredients',
-          tabBarIcon: ({ color }) => (
-            <MaterialIcons size={28} name="shopping-cart" color={color} />
-          ),
-        }}
-      />
-    </Tabs>
+    <View style={{ flex: 1 }}>
+      <GeneralMenu />
+      <Tabs
+        screenOptions={{
+          tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+          headerShown: false,
+          tabBarButton: HapticTab,
+          tabBarBackground: TabBarBackground,
+          tabBarStyle: Platform.select({
+            ios: {
+              // Use a transparent background on iOS to show the blur effect
+              position: 'absolute',
+            },
+            default: {},
+          }),
+        }}>
+        <Tabs.Screen
+          name="cocktails"
+          options={{
+            title: 'Cocktails',
+            tabBarIcon: ({ color }) => (
+              <MaterialIcons size={28} name="local-bar" color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="shaker"
+          options={{
+            title: 'Shaker',
+            tabBarIcon: ({ color }) => (
+              <MaterialIcons size={28} name="science" color={color} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="ingredients"
+          options={{
+            title: 'Ingredients',
+            tabBarIcon: ({ color }) => (
+              <MaterialIcons size={28} name="shopping-cart" color={color} />
+            ),
+          }}
+        />
+      </Tabs>
+    </View>
   );
 }

--- a/components/GeneralMenu.tsx
+++ b/components/GeneralMenu.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, TextInput, Pressable, StyleSheet } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+import { Colors } from '@/constants/Colors';
+import { useColorScheme } from '@/hooks/useColorScheme';
+
+export default function GeneralMenu() {
+  const colorScheme = useColorScheme();
+  const scheme = colorScheme ?? 'light';
+
+  const tintColor = Colors[scheme].tint;
+  const iconColor = Colors[scheme].icon;
+  const textColor = Colors[scheme].text;
+  const backgroundColor = Colors[scheme].background;
+
+  return (
+    <View style={[styles.container, { backgroundColor }]}> 
+      <Pressable onPress={() => {}}>
+        <MaterialIcons name="menu" size={24} color={tintColor} />
+      </Pressable>
+      <TextInput
+        placeholder="Search"
+        placeholderTextColor={iconColor}
+        style={[styles.input, { borderColor: iconColor, color: textColor }]} 
+      />
+      <Pressable onPress={() => {}}>
+        <MaterialIcons name="filter-list" size={24} color={tintColor} />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  input: {
+    flex: 1,
+    marginHorizontal: 16,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+    borderWidth: 1,
+    borderRadius: 8,
+  },
+});
+


### PR DESCRIPTION
## Summary
- create top GeneralMenu component with menu, search, and filter buttons
- render GeneralMenu above tab navigator

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae3f696f3883268f8c745f7bdaa403