### PR TITLE
fix: make safe area transparent

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <SafeAreaView style={{ flex: 1 }}>
+        <SafeAreaView style={{ flex: 1, backgroundColor: 'transparent' }}>
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
             <Stack.Screen name="+not-found" />


### PR DESCRIPTION
## Summary
- make root layout SafeAreaView transparent

## Testing
- `npm test` (fails: missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ae3ff39cc883269f45a15e4a6daed8