### PR TITLE
refactor: use theme colors and clean status bar

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -6,18 +6,18 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { HapticTab } from '@/components/HapticTab';
 import GeneralMenu from '@/components/GeneralMenu';
 import TabBarBackground from '@/components/ui/TabBarBackground';
-import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
+// eslint-disable-next-line import/no-unresolved
+import { useTheme } from 'react-native-paper';
 
 export default function TabLayout() {
-  const colorScheme = useColorScheme();
+  const { colors } = useTheme();
 
   return (
     <View style={{ flex: 1 }}>
       <GeneralMenu />
       <Tabs
         screenOptions={{
-          tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+          tabBarActiveTintColor: colors.primary,
           headerShown: false,
           tabBarButton: HapticTab,
           tabBarBackground: TabBarBackground,

--- a/app/(tabs)/cocktails/_layout.tsx
+++ b/app/(tabs)/cocktails/_layout.tsx
@@ -1,5 +1,3 @@
-import { withLayoutContext } from 'expo-router';
-// eslint-disable-next-line import/no-unresolved
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React from 'react';
 

--- a/app/(tabs)/ingredients/all.tsx
+++ b/app/(tabs)/ingredients/all.tsx
@@ -4,20 +4,20 @@ import { useRouter } from 'expo-router';
 
 import { ThemedView } from '@/components/ThemedView';
 import IngredientList from '@/components/IngredientList';
-import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
+// eslint-disable-next-line import/no-unresolved
+import { useTheme } from 'react-native-paper';
 
 export default function AllIngredientsScreen() {
   const router = useRouter();
-  const colorScheme = useColorScheme();
+  const { colors } = useTheme();
   return (
     <ThemedView style={{ flex: 1 }}>
       <IngredientList />
       <TouchableOpacity
-        style={[styles.fab, { backgroundColor: Colors[colorScheme ?? 'light'].tint }]}
+        style={[styles.fab, { backgroundColor: colors.primary }]}
         onPress={() => router.push('/add-ingredient')}
       >
-        <MaterialIcons name="add" size={24} color="#fff" />
+        <MaterialIcons name="add" size={24} color={colors.onPrimary} />
       </TouchableOpacity>
     </ThemedView>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -4,6 +4,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+// eslint-disable-next-line import/no-unresolved
 import { PaperProvider } from 'react-native-paper';
 
 import { AppTheme } from '@/constants/AppTheme';
@@ -30,7 +31,7 @@ export default function RootLayout() {
               <Stack.Screen name="+not-found" />
             </Stack>
           </SafeAreaView>
-          <StatusBar style="dark" backgroundColor={AppTheme.colors.background} />
+          <StatusBar style="dark" />
         </ThemeProvider>
       </PaperProvider>
     </SafeAreaProvider>

--- a/components/Collapsible.tsx
+++ b/components/Collapsible.tsx
@@ -4,12 +4,12 @@ import { StyleSheet, TouchableOpacity } from 'react-native';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
-import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
+// eslint-disable-next-line import/no-unresolved
+import { useTheme } from 'react-native-paper';
 
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
-  const theme = useColorScheme() ?? 'light';
+  const { colors } = useTheme();
 
   return (
     <ThemedView>
@@ -17,13 +17,13 @@ export function Collapsible({ children, title }: PropsWithChildren & { title: st
         style={styles.heading}
         onPress={() => setIsOpen((value) => !value)}
         activeOpacity={0.8}>
-        <IconSymbol
-          name="chevron.right"
-          size={18}
-          weight="medium"
-          color={theme === 'light' ? Colors.light.icon : Colors.dark.icon}
-          style={{ transform: [{ rotate: isOpen ? '90deg' : '0deg' }] }}
-        />
+          <IconSymbol
+            name="chevron.right"
+            size={18}
+            weight="medium"
+            color={colors.onSurfaceVariant}
+            style={{ transform: [{ rotate: isOpen ? '90deg' : '0deg' }] }}
+          />
 
         <ThemedText type="defaultSemiBold">{title}</ThemedText>
       </TouchableOpacity>

--- a/components/GeneralMenu.tsx
+++ b/components/GeneralMenu.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import { View, TextInput, Pressable, StyleSheet } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
-
-import { Colors } from '@/constants/Colors';
-import { useColorScheme } from '@/hooks/useColorScheme';
+// eslint-disable-next-line import/no-unresolved
+import { useTheme } from 'react-native-paper';
 
 export default function GeneralMenu() {
-  const colorScheme = useColorScheme();
-  const scheme = colorScheme ?? 'light';
+  const { colors } = useTheme();
 
-  const tintColor = Colors[scheme].tint;
-  const iconColor = Colors[scheme].icon;
-  const textColor = Colors[scheme].text;
-  const backgroundColor = Colors[scheme].background;
+  const tintColor = colors.primary;
+  const iconColor = colors.onSurfaceVariant;
+  const textColor = colors.onSurface;
+  const backgroundColor = colors.background;
 
   return (
     <View style={[styles.container, { backgroundColor }]}> 

--- a/components/IngredientList.tsx
+++ b/components/IngredientList.tsx
@@ -2,32 +2,35 @@ import React from 'react';
 import { FlatList, StyleSheet, View } from 'react-native';
 import { Image } from 'expo-image';
 import { ThemedText } from '@/components/ThemedText';
-
-const DATA = [
-  {
-    id: '1',
-    name: 'Absinthe',
-    cocktails: 6,
-    color: '#4CAF50',
-  },
-  {
-    id: '2',
-    name: 'Absolut Citron',
-    cocktails: 11,
-    color: '#FFC107',
-  },
-  {
-    id: '3',
-    name: 'Absolut Vodka',
-    cocktails: 11,
-    color: '#03A9F4',
-  },
-];
+// eslint-disable-next-line import/no-unresolved
+import { useTheme } from 'react-native-paper';
 
 export default function IngredientList() {
+  const { colors } = useTheme();
+  const data = [
+    {
+      id: '1',
+      name: 'Absinthe',
+      cocktails: 6,
+      color: colors.primary,
+    },
+    {
+      id: '2',
+      name: 'Absolut Citron',
+      cocktails: 11,
+      color: colors.secondary,
+    },
+    {
+      id: '3',
+      name: 'Absolut Vodka',
+      cocktails: 11,
+      color: colors.tertiary,
+    },
+  ];
+
   return (
     <FlatList
-      data={DATA}
+      data={data}
       keyExtractor={(item) => item.id}
       renderItem={({ item }) => (
         <View style={styles.item}>
@@ -37,12 +40,15 @@ export default function IngredientList() {
           />
           <View style={{ flex: 1 }}>
             <ThemedText>{item.name}</ThemedText>
-            <ThemedText type="default" style={styles.subtitle}>
+            <ThemedText
+              type="default"
+              style={[styles.subtitle, { color: colors.onSurfaceVariant }]}
+            >
               {item.cocktails} cocktails
             </ThemedText>
           </View>
           <View style={[styles.dot, { backgroundColor: item.color }]} />
-          <View style={styles.circle} />
+          <View style={[styles.circle, { borderColor: colors.outline }]} />
         </View>
       )}
     />
@@ -62,7 +68,6 @@ const styles = StyleSheet.create({
     marginRight: 12,
   },
   subtitle: {
-    color: '#888',
     fontSize: 12,
   },
   dot: {
@@ -76,6 +81,5 @@ const styles = StyleSheet.create({
     height: 24,
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: '#999',
   },
 });

--- a/components/ThemedText.tsx
+++ b/components/ThemedText.tsx
@@ -15,7 +15,10 @@ export function ThemedText({
   type = 'default',
   ...rest
 }: ThemedTextProps) {
-  const color = useThemeColor({ light: lightColor, dark: darkColor }, 'text');
+  const color = useThemeColor(
+    { light: lightColor, dark: darkColor },
+    type === 'link' ? 'tint' : 'text'
+  );
 
   return (
     <Text
@@ -55,6 +58,5 @@ const styles = StyleSheet.create({
   link: {
     lineHeight: 30,
     fontSize: 16,
-    color: '#0a7ea4',
   },
 });


### PR DESCRIPTION
## Summary
- replace hard-coded colors with theme colors across components and tabs
- remove StatusBar background color to resolve edge-to-edge warning
- tidy cocktail tabs layout lint directive

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae447438e0832691e018fcbaa212e9