### PR TITLE
feat: add square Add button

### DIFF
--- a/app/(tabs)/cocktails/_layout.tsx
+++ b/app/(tabs)/cocktails/_layout.tsx
@@ -1,5 +1,4 @@
 import { withLayoutContext } from 'expo-router';
-// eslint-disable-next-line import/no-unresolved
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React from 'react';
 

--- a/app/(tabs)/cocktails/all.tsx
+++ b/app/(tabs)/cocktails/all.tsx
@@ -1,14 +1,14 @@
-import { Button } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import { AddButton } from '@/components/AddButton';
 
 export default function AllCocktailsScreen() {
   const router = useRouter();
   return (
-    <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
+    <ThemedView style={{ flex: 1, padding: 16 }}>
       <ThemedText type="title">All Cocktails</ThemedText>
-      <Button title="Add" onPress={() => router.push('/add-cocktail')} />
+      <AddButton onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/cocktails/favorites.tsx
+++ b/app/(tabs)/cocktails/favorites.tsx
@@ -1,14 +1,14 @@
-import { Button } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import { AddButton } from '@/components/AddButton';
 
 export default function FavoriteCocktailsScreen() {
   const router = useRouter();
   return (
-    <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
+    <ThemedView style={{ flex: 1, padding: 16 }}>
       <ThemedText type="title">Favorite Cocktails</ThemedText>
-      <Button title="Add" onPress={() => router.push('/add-cocktail')} />
+      <AddButton onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/cocktails/my.tsx
+++ b/app/(tabs)/cocktails/my.tsx
@@ -1,14 +1,14 @@
-import { Button } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
+import { AddButton } from '@/components/AddButton';
 
 export default function MyCocktailsScreen() {
   const router = useRouter();
   return (
-    <ThemedView style={{ flex: 1, justifyContent: 'space-between', padding: 16 }}>
+    <ThemedView style={{ flex: 1, padding: 16 }}>
       <ThemedText type="title">My Cocktails</ThemedText>
-      <Button title="Add" onPress={() => router.push('/add-cocktail')} />
+      <AddButton onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/components/AddButton.tsx
+++ b/components/AddButton.tsx
@@ -1,0 +1,31 @@
+import { Pressable, StyleSheet } from 'react-native';
+import { ThemedText } from '@/components/ThemedText';
+import { useThemeColor } from '@/hooks/useThemeColor';
+
+type AddButtonProps = {
+  onPress: () => void;
+};
+
+export function AddButton({ onPress }: AddButtonProps) {
+  const backgroundColor = useThemeColor({}, 'tint');
+  return (
+    <Pressable onPress={onPress} style={[styles.button, { backgroundColor }]}> 
+      <ThemedText lightColor="#fff" darkColor="#000">
+        Add
+      </ThemedText>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16,
+    width: 64,
+    height: 64,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
## Summary
- add reusable AddButton component using theme colors
- show Add button in cocktail tab screens positioned bottom-right with rounded square style

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae454713fc8326be3c2a21c70cfdd7