### PR TITLE
fix: import layout context for cocktails tabs

### DIFF
--- a/app/(tabs)/cocktails/_layout.tsx
+++ b/app/(tabs)/cocktails/_layout.tsx
@@ -1,3 +1,4 @@
+import { withLayoutContext } from 'expo-router';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React from 'react';
 


### PR DESCRIPTION
## Summary
- add missing `withLayoutContext` import in cocktails tab layout

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae46b42ad08326a6695c64ddeeb4b3