### PR TITLE
feat: show add button on ingredient screens

### DIFF
--- a/app/(tabs)/ingredients/all.tsx
+++ b/app/(tabs)/ingredients/all.tsx
@@ -1,37 +1,15 @@
-import { StyleSheet, TouchableOpacity } from 'react-native';
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useRouter } from 'expo-router';
 
 import { ThemedView } from '@/components/ThemedView';
 import IngredientList from '@/components/IngredientList';
-// eslint-disable-next-line import/no-unresolved
-import { useTheme } from 'react-native-paper';
+import { AddButton } from '@/components/AddButton';
 
 export default function AllIngredientsScreen() {
   const router = useRouter();
-  const { colors } = useTheme();
   return (
     <ThemedView style={{ flex: 1 }}>
       <IngredientList />
-      <TouchableOpacity
-        style={[styles.fab, { backgroundColor: colors.primary }]}
-        onPress={() => router.push('/add-ingredient')}
-      >
-        <MaterialIcons name="add" size={24} color={colors.onPrimary} />
-      </TouchableOpacity>
+      <AddButton onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }
-
-const styles = StyleSheet.create({
-  fab: {
-    position: 'absolute',
-    bottom: 16,
-    right: 16,
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-});

--- a/app/(tabs)/ingredients/my.tsx
+++ b/app/(tabs)/ingredients/my.tsx
@@ -1,10 +1,14 @@
 import { ThemedView } from '@/components/ThemedView';
 import IngredientList from '@/components/IngredientList';
+import { AddButton } from '@/components/AddButton';
+import { useRouter } from 'expo-router';
 
 export default function MyIngredientsScreen() {
+  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1 }}>
       <IngredientList />
+      <AddButton onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/ingredients/shopping.tsx
+++ b/app/(tabs)/ingredients/shopping.tsx
@@ -1,10 +1,14 @@
 import { ThemedView } from '@/components/ThemedView';
 import IngredientList from '@/components/IngredientList';
+import { AddButton } from '@/components/AddButton';
+import { useRouter } from 'expo-router';
 
 export default function ShoppingIngredientsScreen() {
+  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1 }}>
       <IngredientList />
+      <AddButton onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }


### PR DESCRIPTION
## Summary
- ensure all ingredient tabs reuse shared Add button for new ingredients

## Testing
- `npm test`
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ae4940a9708326b7ad1680e590c66d