### PR TITLE
feat: add side drawer menu

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,20 +1,22 @@
 import { Tabs } from 'expo-router';
-import React from 'react';
+import React, { useState } from 'react';
 import { Platform, View } from 'react-native';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 import { HapticTab } from '@/components/HapticTab';
 import GeneralMenu from '@/components/GeneralMenu';
+import SideMenu from '@/components/SideMenu';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 // eslint-disable-next-line import/no-unresolved
 import { useTheme } from 'react-native-paper';
 
 export default function TabLayout() {
   const { colors } = useTheme();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <View style={{ flex: 1 }}>
-      <GeneralMenu />
+      <GeneralMenu onMenuPress={() => setMenuOpen(true)} />
       <Tabs
         screenOptions={{
           tabBarActiveTintColor: colors.primary,
@@ -57,6 +59,7 @@ export default function TabLayout() {
           }}
         />
       </Tabs>
+      <SideMenu visible={menuOpen} onClose={() => setMenuOpen(false)} />
     </View>
   );
 }

--- a/components/GeneralMenu.tsx
+++ b/components/GeneralMenu.tsx
@@ -4,7 +4,11 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 // eslint-disable-next-line import/no-unresolved
 import { useTheme } from 'react-native-paper';
 
-export default function GeneralMenu() {
+interface GeneralMenuProps {
+  onMenuPress?: () => void;
+}
+
+export default function GeneralMenu({ onMenuPress }: GeneralMenuProps) {
   const { colors } = useTheme();
 
   const tintColor = colors.primary;
@@ -14,7 +18,7 @@ export default function GeneralMenu() {
 
   return (
     <View style={[styles.container, { backgroundColor }]}> 
-      <Pressable onPress={() => {}}>
+      <Pressable onPress={onMenuPress}>
         <MaterialIcons name="menu" size={24} color={tintColor} />
       </Pressable>
       <TextInput

--- a/components/SideMenu.tsx
+++ b/components/SideMenu.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, Dimensions, Pressable, StyleSheet, View, Text } from 'react-native';
+import { Link } from 'expo-router';
+// eslint-disable-next-line import/no-unresolved
+import { useTheme } from 'react-native-paper';
+
+interface SideMenuProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function SideMenu({ visible, onClose }: SideMenuProps) {
+  const { colors } = useTheme();
+  const screenWidth = Dimensions.get('window').width;
+  const drawerWidth = screenWidth * 0.75;
+  const translateX = useRef(new Animated.Value(-drawerWidth)).current;
+  const [render, setRender] = useState(visible);
+
+  useEffect(() => {
+    if (visible) {
+      setRender(true);
+      Animated.timing(translateX, {
+        toValue: 0,
+        duration: 250,
+        useNativeDriver: true,
+      }).start();
+    } else {
+      Animated.timing(translateX, {
+        toValue: -drawerWidth,
+        duration: 250,
+        useNativeDriver: true,
+      }).start(() => setRender(false));
+    }
+  }, [visible, drawerWidth, translateX]);
+
+  if (!render) {
+    return null;
+  }
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      <Pressable style={[StyleSheet.absoluteFill, { backgroundColor: colors.backdrop }]} onPress={onClose} />
+      <Animated.View
+        style={[
+          styles.drawer,
+          {
+            width: drawerWidth,
+            backgroundColor: colors.surface,
+            transform: [{ translateX }],
+          },
+        ]}
+      >
+        <Text style={[styles.title, { color: colors.onSurface }]}>Main Menu</Text>
+        <Link href="/(tabs)/cocktails" asChild>
+          <Pressable style={styles.menuItem} onPress={onClose}>
+            <Text style={{ color: colors.onSurface }}>Cocktails</Text>
+          </Pressable>
+        </Link>
+        <Link href="/(tabs)/shaker" asChild>
+          <Pressable style={styles.menuItem} onPress={onClose}>
+            <Text style={{ color: colors.onSurface }}>Shaker</Text>
+          </Pressable>
+        </Link>
+        <Link href="/(tabs)/ingredients" asChild>
+          <Pressable style={styles.menuItem} onPress={onClose}>
+            <Text style={{ color: colors.onSurface }}>Ingredients</Text>
+          </Pressable>
+        </Link>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  drawer: {
+    height: '100%',
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    paddingTop: 48,
+    paddingHorizontal: 16,
+  },
+  title: {
+    fontSize: 18,
+    marginBottom: 16,
+  },
+  menuItem: {
+    paddingVertical: 12,
+  },
+});
+


### PR DESCRIPTION
## Summary
- add SideMenu component to slide in from left covering 75% width
- wire GeneralMenu's menu button to open the side drawer
- manage drawer state in tab layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc --noEmit` *(fails: Type 'number' is not assignable to type '3')*


------
https://chatgpt.com/codex/tasks/task_e_68ae4bd3a61c8326b40a85687816d875