### PR TITLE
Add ingredient tag management modal and menu entry

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -6,6 +6,7 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { HapticTab } from '@/components/HapticTab';
 import GeneralMenu from '@/components/GeneralMenu';
 import SideMenu from '@/components/SideMenu';
+import ManageTagsModal from '@/components/ManageTagsModal';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 // eslint-disable-next-line import/no-unresolved
 import { useTheme } from 'react-native-paper';
@@ -13,6 +14,7 @@ import { useTheme } from 'react-native-paper';
 export default function TabLayout() {
   const { colors } = useTheme();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [tagsModalVisible, setTagsModalVisible] = useState(false);
 
   return (
     <View style={{ flex: 1 }}>
@@ -59,7 +61,12 @@ export default function TabLayout() {
           }}
         />
       </Tabs>
-      <SideMenu visible={menuOpen} onClose={() => setMenuOpen(false)} />
+      <SideMenu
+        visible={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onManageTags={() => setTagsModalVisible(true)}
+      />
+      <ManageTagsModal visible={tagsModalVisible} onDismiss={() => setTagsModalVisible(false)} />
     </View>
   );
 }

--- a/components/ManageTagsModal.tsx
+++ b/components/ManageTagsModal.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+// eslint-disable-next-line import/no-unresolved
+import { Modal, Portal, Text, Button, TextInput, Chip, useTheme } from 'react-native-paper';
+
+interface ManageTagsModalProps {
+  visible: boolean;
+  onDismiss: () => void;
+}
+
+export default function ManageTagsModal({ visible, onDismiss }: ManageTagsModalProps) {
+  const { colors } = useTheme();
+  const [tag, setTag] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
+
+  const handleAddTag = () => {
+    const value = tag.trim();
+    if (value && !tags.includes(value)) {
+      setTags([...tags, value]);
+    }
+    setTag('');
+  };
+
+  const handleRemoveTag = (value: string) => {
+    setTags(tags.filter((t) => t !== value));
+  };
+
+  return (
+    <Portal>
+      <Modal visible={visible} onDismiss={onDismiss} contentContainerStyle={[styles.modal, { backgroundColor: colors.surface }]}> 
+        <Text variant="titleMedium" style={styles.title}>
+          Manage Ingredients Tags
+        </Text>
+        <View style={styles.inputRow}>
+          <TextInput
+            mode="outlined"
+            placeholder="New tag"
+            value={tag}
+            onChangeText={setTag}
+            style={styles.input}
+          />
+          <Button mode="contained" onPress={handleAddTag} style={styles.addButton}>
+            Add
+          </Button>
+        </View>
+        <View style={styles.tagsContainer}>
+          {tags.map((t) => (
+            <Chip key={t} onClose={() => handleRemoveTag(t)} style={styles.chip}>
+              {t}
+            </Chip>
+          ))}
+        </View>
+        <Button onPress={onDismiss} style={styles.closeButton}>
+          Close
+        </Button>
+      </Modal>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modal: {
+    margin: 20,
+    padding: 20,
+    borderRadius: 8,
+  },
+  title: {
+    marginBottom: 16,
+    textAlign: 'center',
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  input: {
+    flex: 1,
+    marginRight: 8,
+  },
+  addButton: {
+    marginLeft: 8,
+  },
+  tagsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 16,
+  },
+  chip: {
+    margin: 4,
+  },
+  closeButton: {
+    marginTop: 16,
+  },
+});

--- a/components/SideMenu.tsx
+++ b/components/SideMenu.tsx
@@ -7,9 +7,10 @@ import { useTheme } from 'react-native-paper';
 interface SideMenuProps {
   visible: boolean;
   onClose: () => void;
+  onManageTags?: () => void;
 }
 
-export default function SideMenu({ visible, onClose }: SideMenuProps) {
+export default function SideMenu({ visible, onClose, onManageTags }: SideMenuProps) {
   const { colors } = useTheme();
   const screenWidth = Dimensions.get('window').width;
   const drawerWidth = screenWidth * 0.75;
@@ -66,6 +67,15 @@ export default function SideMenu({ visible, onClose }: SideMenuProps) {
             <Text style={{ color: colors.onSurface }}>Ingredients</Text>
           </Pressable>
         </Link>
+        <Pressable
+          style={styles.menuItem}
+          onPress={() => {
+            onClose();
+            onManageTags?.();
+          }}
+        >
+          <Text style={{ color: colors.onSurface }}>Manage ingredients tag</Text>
+        </Pressable>
       </Animated.View>
     </View>
   );


### PR DESCRIPTION
## Summary
- add ManageTagsModal component for creating and removing ingredient tags
- expose tag management from the side menu via new menu item
- integrate modal control into tab layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae4db5ae3883268efd6a0e8c859021