### PR TITLE
Keep Add button fixed across tab screens

### DIFF
--- a/app/(tabs)/cocktails/_layout.tsx
+++ b/app/(tabs)/cocktails/_layout.tsx
@@ -1,17 +1,24 @@
-import { withLayoutContext } from 'expo-router';
+import { withLayoutContext, useRouter } from 'expo-router';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React from 'react';
+import { View } from 'react-native';
+
+import { AddButton } from '@/components/AddButton';
 
 const { Navigator } = createMaterialTopTabNavigator();
 
 export const Tabs = withLayoutContext(Navigator);
 
 export default function CocktailsLayout() {
+  const router = useRouter();
   return (
-    <Tabs>
-      <Tabs.Screen name="all" options={{ title: 'All' }} />
-      <Tabs.Screen name="my" options={{ title: 'My' }} />
-      <Tabs.Screen name="favorites" options={{ title: 'Favorites' }} />
-    </Tabs>
+    <View style={{ flex: 1 }}>
+      <Tabs>
+        <Tabs.Screen name="all" options={{ title: 'All' }} />
+        <Tabs.Screen name="my" options={{ title: 'My' }} />
+        <Tabs.Screen name="favorites" options={{ title: 'Favorites' }} />
+      </Tabs>
+      <AddButton onPress={() => router.push('/add-cocktail')} />
+    </View>
   );
 }

--- a/app/(tabs)/cocktails/all.tsx
+++ b/app/(tabs)/cocktails/all.tsx
@@ -1,14 +1,10 @@
-import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { AddButton } from '@/components/AddButton';
 
 export default function AllCocktailsScreen() {
-  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, padding: 16 }}>
       <ThemedText type="title">All Cocktails</ThemedText>
-      <AddButton onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/cocktails/favorites.tsx
+++ b/app/(tabs)/cocktails/favorites.tsx
@@ -1,14 +1,10 @@
-import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { AddButton } from '@/components/AddButton';
 
 export default function FavoriteCocktailsScreen() {
-  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, padding: 16 }}>
       <ThemedText type="title">Favorite Cocktails</ThemedText>
-      <AddButton onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/cocktails/my.tsx
+++ b/app/(tabs)/cocktails/my.tsx
@@ -1,14 +1,10 @@
-import { useRouter } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
-import { AddButton } from '@/components/AddButton';
 
 export default function MyCocktailsScreen() {
-  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1, padding: 16 }}>
       <ThemedText type="title">My Cocktails</ThemedText>
-      <AddButton onPress={() => router.push('/add-cocktail')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/ingredients/_layout.tsx
+++ b/app/(tabs)/ingredients/_layout.tsx
@@ -1,7 +1,9 @@
-import { withLayoutContext } from 'expo-router';
+import { withLayoutContext, useRouter } from 'expo-router';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import React from 'react';
 import { View } from 'react-native';
+
+import { AddButton } from '@/components/AddButton';
 
 
 const { Navigator } = createMaterialTopTabNavigator();
@@ -9,6 +11,7 @@ const { Navigator } = createMaterialTopTabNavigator();
 export const Tabs = withLayoutContext(Navigator);
 
 export default function IngredientsLayout() {
+  const router = useRouter();
   return (
     <View style={{ flex: 1 }}>
       <Tabs>
@@ -16,6 +19,7 @@ export default function IngredientsLayout() {
         <Tabs.Screen name="my" options={{ title: 'My' }} />
         <Tabs.Screen name="shopping" options={{ title: 'Shopping' }} />
       </Tabs>
+      <AddButton onPress={() => router.push('/add-ingredient')} />
     </View>
   );
 }

--- a/app/(tabs)/ingredients/all.tsx
+++ b/app/(tabs)/ingredients/all.tsx
@@ -1,15 +1,10 @@
-import { useRouter } from 'expo-router';
-
 import { ThemedView } from '@/components/ThemedView';
 import IngredientList from '@/components/IngredientList';
-import { AddButton } from '@/components/AddButton';
 
 export default function AllIngredientsScreen() {
-  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1 }}>
       <IngredientList />
-      <AddButton onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/ingredients/my.tsx
+++ b/app/(tabs)/ingredients/my.tsx
@@ -1,14 +1,10 @@
 import { ThemedView } from '@/components/ThemedView';
 import IngredientList from '@/components/IngredientList';
-import { AddButton } from '@/components/AddButton';
-import { useRouter } from 'expo-router';
 
 export default function MyIngredientsScreen() {
-  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1 }}>
       <IngredientList />
-      <AddButton onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }

--- a/app/(tabs)/ingredients/shopping.tsx
+++ b/app/(tabs)/ingredients/shopping.tsx
@@ -1,14 +1,10 @@
 import { ThemedView } from '@/components/ThemedView';
 import IngredientList from '@/components/IngredientList';
-import { AddButton } from '@/components/AddButton';
-import { useRouter } from 'expo-router';
 
 export default function ShoppingIngredientsScreen() {
-  const router = useRouter();
   return (
     <ThemedView style={{ flex: 1 }}>
       <IngredientList />
-      <AddButton onPress={() => router.push('/add-ingredient')} />
     </ThemedView>
   );
 }


### PR DESCRIPTION
## Summary
- Place Add button in cocktails and ingredients tab layouts so it no longer moves with nested tab transitions
- Remove redundant Add button instances from individual tab screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae4e2b5bf083268142b5544bbc987b