### PR TITLE
feat: add default ingredient tags

### DIFF
--- a/constants/IngredientTags.ts
+++ b/constants/IngredientTags.ts
@@ -1,0 +1,31 @@
+export const TAG_COLORS = [
+  "#ec5a5a", // 0
+  "#F06292", // 1
+  "#BA68C8", // 2
+  "#9575CD", // 3
+  "#7986CB", // 4
+  "#64B5F6", // 5
+  "#4FC3F7", // 6
+  "#4DD0E1", // 7
+  "#4DB6AC", // 8
+  "#81C784", // 9
+  "#AED581", // 10
+  "#DCE775", // 11
+  "#FFD54F", // 12
+  "#FFB74D", // 13
+  "#FF8A65", // 14
+  "#a8a8a8", // 15
+];
+
+export const INGREDIENT_TAGS = [
+  { id: 1, name: "strong alcohol", color: TAG_COLORS[0] },
+  { id: 2, name: "soft alcohol", color: TAG_COLORS[1] },
+  { id: 3, name: "beverage", color: TAG_COLORS[3] },
+  { id: 4, name: "syrup", color: TAG_COLORS[13] },
+  { id: 5, name: "juice", color: TAG_COLORS[10] },
+  { id: 6, name: "fruit", color: TAG_COLORS[9] },
+  { id: 7, name: "herb", color: TAG_COLORS[8] },
+  { id: 8, name: "spice", color: TAG_COLORS[14] },
+  { id: 9, name: "dairy", color: TAG_COLORS[6] },
+  { id: 10, name: "other", color: TAG_COLORS[15] },
+];


### PR DESCRIPTION
## Summary
- add TAG_COLORS and INGREDIENT_TAGS constants for built-in ingredient tagging

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae4f3207f48326a61a6d97d85a81f1