### PR TITLE
feat: add ingredient creation form

### DIFF
--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -1,10 +1,203 @@
-import { ThemedView } from '@/components/ThemedView';
-import { ThemedText } from '@/components/ThemedText';
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Image,
+  StyleSheet,
+  ScrollView,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { useRouter } from 'expo-router';
+
+import { getAllTags, type IngredientTag } from '@/storage/ingredientTagsStorage';
+import { INGREDIENT_TAGS } from '@/constants/IngredientTags';
+import { addIngredient } from '@/storage/ingredientsStorage';
 
 export default function AddIngredientScreen() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [photoUri, setPhotoUri] = useState<string | null>(null);
+  const [tags, setTags] = useState<IngredientTag[]>([]);
+  const [availableTags, setAvailableTags] = useState<IngredientTag[]>([]);
+
+  useEffect(() => {
+    const loadTags = async () => {
+      const custom = await getAllTags();
+      setAvailableTags([...INGREDIENT_TAGS, ...custom]);
+    };
+    loadTags();
+  }, []);
+
+  const toggleTag = (tag: IngredientTag) => {
+    if (tags.find((t) => t.id === tag.id)) {
+      setTags(tags.filter((t) => t.id !== tag.id));
+    } else {
+      setTags([...tags, tag]);
+    }
+  };
+
+  const pickImage = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      Alert.alert('Permission required', 'Allow access to media library');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (!result.canceled) {
+      setPhotoUri(result.assets[0].uri);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      Alert.alert('Please enter a name for the ingredient.');
+      return;
+    }
+    const id = Date.now();
+    await addIngredient({ id, name: name.trim(), description, photoUri, tags });
+    router.back();
+  };
+
   return (
-    <ThemedView style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 }}>
-      <ThemedText type="title">Add Ingredient</ThemedText>
-    </ThemedView>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={0}
+    >
+      <ScrollView contentContainerStyle={styles.container}>
+        <Text style={styles.label}>Name:</Text>
+        <TextInput
+          placeholder="e.g. Lemon juice"
+          value={name}
+          onChangeText={setName}
+          style={styles.input}
+        />
+
+        <Text style={styles.label}>Photo:</Text>
+        <TouchableOpacity style={styles.imageButton} onPress={pickImage}>
+          {photoUri ? (
+            <Image source={{ uri: photoUri }} style={styles.image} />
+          ) : (
+            <Text style={styles.imagePlaceholder}>Tap to select image</Text>
+          )}
+        </TouchableOpacity>
+
+        <Text style={styles.label}>Tags:</Text>
+        <View style={styles.tagContainer}>
+          {tags.map((tag) => (
+            <TouchableOpacity
+              key={tag.id}
+              style={[styles.tag, { backgroundColor: tag.color }]}
+              onPress={() => toggleTag(tag)}
+            >
+              <Text style={styles.tagText}>{tag.name}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <Text style={styles.label}>Add Tag:</Text>
+        <View style={styles.tagContainer}>
+          {availableTags
+            .filter((t) => !tags.some((tag) => tag.id === t.id))
+            .map((tag) => (
+              <TouchableOpacity
+                key={tag.id}
+                style={[styles.tag, { backgroundColor: tag.color }]}
+                onPress={() => toggleTag(tag)}
+              >
+                <Text style={styles.tagText}>+ {tag.name}</Text>
+              </TouchableOpacity>
+            ))}
+        </View>
+
+        <Text style={styles.label}>Description:</Text>
+        <TextInput
+          placeholder="Optional description"
+          value={description}
+          onChangeText={setDescription}
+          style={[styles.input, { height: 60 }]}
+          multiline
+        />
+
+        <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
+          <Text style={styles.saveText}>Save Ingredient</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
+
+const IMAGE_SIZE = 120;
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 24,
+    backgroundColor: 'white',
+  },
+  label: {
+    fontWeight: 'bold',
+    marginTop: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    marginTop: 8,
+    borderRadius: 8,
+  },
+  imageButton: {
+    marginTop: 8,
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    backgroundColor: '#eee',
+    borderRadius: 8,
+    overflow: 'hidden',
+    justifyContent: 'center',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+  },
+  image: {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    resizeMode: 'cover',
+  },
+  imagePlaceholder: {
+    color: '#777',
+    textAlign: 'center',
+  },
+  tagContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 8,
+  },
+  tag: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 16,
+    margin: 4,
+  },
+  tagText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  saveButton: {
+    marginTop: 24,
+    backgroundColor: '#4DABF7',
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderRadius: 8,
+  },
+  saveText: {
+    color: 'white',
+    fontWeight: 'bold',
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
+        "expo-image-picker": "^16.1.4",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.5",
         "expo-splash-screen": "~0.30.10",
@@ -6284,6 +6285,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",
+    "expo-image-picker": "^16.1.4",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.5",
     "expo-splash-screen": "~0.30.10",

--- a/storage/ingredientTagsStorage.ts
+++ b/storage/ingredientTagsStorage.ts
@@ -1,0 +1,11 @@
+export type IngredientTag = {
+  id: number;
+  name: string;
+  color: string;
+};
+
+export async function getAllTags(): Promise<IngredientTag[]> {
+  // In a full implementation this would load custom tags from persistent storage.
+  // Currently, no custom tags are stored so we simply return an empty array.
+  return [];
+}

--- a/storage/ingredientsStorage.ts
+++ b/storage/ingredientsStorage.ts
@@ -1,0 +1,14 @@
+import type { IngredientTag } from './ingredientTagsStorage';
+
+export type Ingredient = {
+  id: number;
+  name: string;
+  description?: string;
+  photoUri?: string | null;
+  tags: IngredientTag[];
+};
+
+export async function addIngredient(ingredient: Ingredient): Promise<void> {
+  // TODO: persist ingredient data
+  console.log('Ingredient saved', ingredient);
+}


### PR DESCRIPTION
## Summary
- add ingredient creation screen with name, image picker, tags, and description
- scaffold ingredient and tag storage modules
- install expo-image-picker dependency

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae50e41c2483269a5a8df840425db1