### PR TITLE
Persist ingredients in SQLite database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.5",
         "expo-splash-screen": "~0.30.10",
+        "expo-sqlite": "^15.2.14",
         "expo-status-bar": "~2.2.3",
         "expo-symbols": "~0.4.5",
         "expo-system-ui": "~5.0.11",
@@ -4276,6 +4277,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -6423,6 +6430,20 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "15.2.14",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-15.2.14.tgz",
+      "integrity": "sha512-6tWnEE0fcir30/e7eVwjeC7eKdncfVnIgo2JvnKpRndedyiFMXLMyOQWNVGnuhnSrPV2BHvGGjLByS/j5VgH4w==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.5",
     "expo-splash-screen": "~0.30.10",
+    "expo-sqlite": "^15.2.14",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.11",

--- a/storage/ingredientsStorage.ts
+++ b/storage/ingredientsStorage.ts
@@ -1,3 +1,4 @@
+import { openDatabaseSync } from 'expo-sqlite';
 import type { IngredientTag } from './ingredientTagsStorage';
 
 export type Ingredient = {
@@ -8,7 +9,25 @@ export type Ingredient = {
   tags: IngredientTag[];
 };
 
+const db = openDatabaseSync('ingredients.db');
+
+db.execSync(
+  `CREATE TABLE IF NOT EXISTS ingredients (
+    id INTEGER PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    photoUri TEXT,
+    tags TEXT
+  );`
+);
+
 export async function addIngredient(ingredient: Ingredient): Promise<void> {
-  // TODO: persist ingredient data
-  console.log('Ingredient saved', ingredient);
+  await db.runAsync(
+    'INSERT INTO ingredients (id, name, description, photoUri, tags) VALUES (?, ?, ?, ?, ?)',
+    ingredient.id,
+    ingredient.name,
+    ingredient.description ?? null,
+    ingredient.photoUri ?? null,
+    JSON.stringify(ingredient.tags),
+  );
 }


### PR DESCRIPTION
## Summary
- add expo-sqlite dependency
- store ingredients in SQLite with columns for name, description, photo and tags

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae53091a5c8326ab83741f6cb862fc