### PR TITLE
Add image cropping and resizing to ingredient form

### DIFF
--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -11,8 +11,8 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
-// eslint-disable-next-line import/no-unresolved
 import * as ImagePicker from 'expo-image-picker';
+import * as ImageManipulator from 'expo-image-manipulator';
 import { useRouter } from 'expo-router';
 
 import { getAllTags, type IngredientTag } from '@/storage/ingredientTagsStorage';
@@ -50,11 +50,18 @@ export default function AddIngredientScreen() {
       return;
     }
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [1, 1],
       quality: 0.7,
     });
     if (!result.canceled) {
-      setPhotoUri(result.assets[0].uri);
+      const resized = await ImageManipulator.manipulateAsync(
+        result.assets[0].uri,
+        [{ resize: { width: 150, height: 150 } }],
+        { compress: 0.7, format: ImageManipulator.SaveFormat.JPEG }
+      );
+      setPhotoUri(resized.uri);
     }
   };
 
@@ -137,7 +144,7 @@ export default function AddIngredientScreen() {
   );
 }
 
-const IMAGE_SIZE = 120;
+const IMAGE_SIZE = 150;
 
 const styles = StyleSheet.create({
   container: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
+        "expo-image-manipulator": "~14.0.3",
         "expo-image-picker": "^16.1.4",
         "expo-linking": "~7.1.7",
         "expo-router": "~5.1.5",
@@ -6298,6 +6299,27 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
       "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-14.0.3.tgz",
+      "integrity": "sha512-Euo8vLZTJA0o5tsT67L40xulQ00gef0pRP1Q0VY0yDyfZvnd7bv/iLCT5PkYQToYavc996dcNdIWeHZ5RZunSg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator/node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",
     "expo-image-picker": "^16.1.4",
+    "expo-image-manipulator": "~14.0.3",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.5",
     "expo-splash-screen": "~0.30.10",


### PR DESCRIPTION
## Summary
- replace deprecated ImagePicker.MediaTypeOptions with MediaType
- allow cropping images and resize uploads to 150x150
- add expo-image-manipulator dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae56c71b70832694443564f8e0fd49