### PR TITLE
feat: expand side menu with tag and export actions

### DIFF
--- a/components/GeneralMenu.tsx
+++ b/components/GeneralMenu.tsx
@@ -1,90 +1,220 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Animated, Dimensions, Pressable, StyleSheet, View, Text } from 'react-native';
-import { Link } from 'expo-router';
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Dimensions,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from 'react-native-paper';
+import { Link } from 'expo-router';
 
 interface GeneralMenuProps {
   visible: boolean;
   onClose: () => void;
 }
 
+const SCREEN_WIDTH = Dimensions.get('window').width;
+const MENU_WIDTH = SCREEN_WIDTH * 0.75;
+
 export default function GeneralMenu({ visible, onClose }: GeneralMenuProps) {
-  const { colors } = useTheme();
-  const screenWidth = Dimensions.get('window').width;
-  const drawerWidth = screenWidth * 0.75;
-  const translateX = useRef(new Animated.Value(-drawerWidth)).current;
-  const [render, setRender] = useState(visible);
+  const theme = useTheme();
+  const slideAnim = useRef(new Animated.Value(-MENU_WIDTH)).current;
 
   useEffect(() => {
     if (visible) {
-      setRender(true);
-      Animated.timing(translateX, {
+      Animated.timing(slideAnim, {
         toValue: 0,
         duration: 250,
-        useNativeDriver: true,
+        useNativeDriver: false,
       }).start();
     } else {
-      Animated.timing(translateX, {
-        toValue: -drawerWidth,
+      Animated.timing(slideAnim, {
+        toValue: -MENU_WIDTH,
         duration: 250,
-        useNativeDriver: true,
-      }).start(() => setRender(false));
+        useNativeDriver: false,
+      }).start();
     }
-  }, [visible, drawerWidth, translateX]);
+  }, [visible, slideAnim]);
 
-  if (!render) {
-    return null;
-  }
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        overlay: {
+          flex: 1,
+          backgroundColor: theme.colors.backdrop,
+          justifyContent: 'flex-start',
+          alignItems: 'flex-start',
+        },
+        menu: {
+          height: '100%',
+          backgroundColor: theme.colors.background,
+          paddingTop: 48,
+          paddingHorizontal: 16,
+        },
+        title: {
+          fontSize: 20,
+          fontWeight: '600',
+          marginBottom: 16,
+          color: theme.colors.onSurface,
+        },
+        linkRow: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          paddingVertical: 14,
+          borderBottomWidth: StyleSheet.hairlineWidth,
+          borderBottomColor: theme.colors.outline,
+        },
+        linkIcon: { marginRight: 8 },
+        itemTitle: {
+          fontSize: 16,
+          color: theme.colors.onSurface,
+        },
+      }),
+    [theme]
+  );
+
+  const handleIngredientTags = () => {
+    onClose();
+    Alert.alert('Ingredient tags', 'Tag editor not implemented');
+  };
+
+  const handleCocktailTags = () => {
+    onClose();
+    Alert.alert('Cocktail tags', 'Tag editor not implemented');
+  };
+
+  const handleExportPhotos = () => {
+    onClose();
+    Alert.alert('Export photos', 'Photo export not implemented');
+  };
+
+  const handleExportData = () => {
+    onClose();
+    Alert.alert('Export data', 'Data export not implemented');
+  };
+
+  const handleImportData = () => {
+    onClose();
+    Alert.alert('Import data', 'Data import not implemented');
+  };
 
   return (
-    <View style={StyleSheet.absoluteFill}>
-      <Pressable style={[StyleSheet.absoluteFill, { backgroundColor: colors.backdrop }]} onPress={onClose} />
-      <Animated.View
-        style={[
-          styles.drawer,
-          {
-            width: drawerWidth,
-            backgroundColor: colors.surface,
-            transform: [{ translateX }],
-          },
-        ]}
-      >
-        <Text style={[styles.title, { color: colors.onSurface }]}>Main Menu</Text>
-        <Link href="/(tabs)/cocktails" asChild>
-          <Pressable style={styles.menuItem} onPress={onClose}>
-            <Text style={{ color: colors.onSurface }}>Cocktails</Text>
-          </Pressable>
-        </Link>
-        <Link href="/(tabs)/shaker" asChild>
-          <Pressable style={styles.menuItem} onPress={onClose}>
-            <Text style={{ color: colors.onSurface }}>Shaker</Text>
-          </Pressable>
-        </Link>
-        <Link href="/(tabs)/ingredients" asChild>
-          <Pressable style={styles.menuItem} onPress={onClose}>
-            <Text style={{ color: colors.onSurface }}>Ingredients</Text>
-          </Pressable>
-        </Link>
-      </Animated.View>
-    </View>
+    <Modal transparent visible={visible} animationType="none" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose}>
+        <Animated.View
+          style={[
+            styles.menu,
+            { width: MENU_WIDTH, transform: [{ translateX: slideAnim }] },
+          ]}
+          onStartShouldSetResponder={() => true}
+        >
+          <ScrollView style={{ marginTop: -32 }}>
+            <Text style={styles.title}>Main Menu</Text>
+
+            <Link href="/(tabs)/cocktails" asChild>
+              <TouchableOpacity
+                style={styles.linkRow}
+                onPress={onClose}
+              >
+                <MaterialIcons
+                  name="menu-book"
+                  size={22}
+                  color={theme.colors.primary}
+                  style={styles.linkIcon}
+                />
+                <Text style={styles.itemTitle}>Cocktails</Text>
+              </TouchableOpacity>
+            </Link>
+
+            <Link href="/(tabs)/shaker" asChild>
+              <TouchableOpacity
+                style={styles.linkRow}
+                onPress={onClose}
+              >
+                <MaterialIcons
+                  name="science"
+                  size={22}
+                  color={theme.colors.primary}
+                  style={styles.linkIcon}
+                />
+                <Text style={styles.itemTitle}>Shaker</Text>
+              </TouchableOpacity>
+            </Link>
+
+            <Link href="/(tabs)/ingredients" asChild>
+              <TouchableOpacity
+                style={styles.linkRow}
+                onPress={onClose}
+              >
+                <MaterialIcons
+                  name="kitchen"
+                  size={22}
+                  color={theme.colors.primary}
+                  style={styles.linkIcon}
+                />
+                <Text style={styles.itemTitle}>Ingredients</Text>
+              </TouchableOpacity>
+            </Link>
+
+            <TouchableOpacity style={styles.linkRow} onPress={handleIngredientTags}>
+              <MaterialIcons
+                name="label"
+                size={22}
+                color={theme.colors.primary}
+                style={styles.linkIcon}
+              />
+              <Text style={styles.itemTitle}>Ingredient tags</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.linkRow} onPress={handleCocktailTags}>
+              <MaterialIcons
+                name="sell"
+                size={22}
+                color={theme.colors.primary}
+                style={styles.linkIcon}
+              />
+              <Text style={styles.itemTitle}>Cocktail tags</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.linkRow} onPress={handleExportPhotos}>
+              <MaterialIcons
+                name="photo-library"
+                size={22}
+                color={theme.colors.primary}
+                style={styles.linkIcon}
+              />
+              <Text style={styles.itemTitle}>Export photos</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.linkRow} onPress={handleExportData}>
+              <MaterialIcons
+                name="file-download"
+                size={22}
+                color={theme.colors.primary}
+                style={styles.linkIcon}
+              />
+              <Text style={styles.itemTitle}>Export data</Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.linkRow} onPress={handleImportData}>
+              <MaterialIcons
+                name="file-upload"
+                size={22}
+                color={theme.colors.primary}
+                style={styles.linkIcon}
+              />
+              <Text style={styles.itemTitle}>Import data</Text>
+            </TouchableOpacity>
+          </ScrollView>
+        </Animated.View>
+      </Pressable>
+    </Modal>
   );
 }
-
-const styles = StyleSheet.create({
-  drawer: {
-    height: '100%',
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    paddingTop: 48,
-    paddingHorizontal: 16,
-  },
-  title: {
-    fontSize: 18,
-    marginBottom: 16,
-  },
-  menuItem: {
-    paddingVertical: 12,
-  },
-});
 


### PR DESCRIPTION
## Summary
- redesign side drawer using modal with animated slide-in
- add actions for ingredient tags, cocktail tags, and data/photo export/import

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aebdf9a5fc8326801da929ed77ee3a