### PR TITLE
feat: move ingredient tags to database

### DIFF
--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -12,13 +12,11 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-// eslint-disable-next-line import/no-unresolved
 import * as ImagePicker from 'expo-image-picker';
 
 import { useRouter } from 'expo-router';
 import { useTheme } from 'react-native-paper';
 
-import { INGREDIENT_TAGS } from '@/constants/IngredientTags';
 import {
   addIngredient,
   getBaseIngredients,
@@ -41,8 +39,8 @@ export default function AddIngredientScreen() {
 
   useEffect(() => {
     const load = async () => {
-      const custom = await getAllTags();
-      setAvailableTags([...INGREDIENT_TAGS, ...custom]);
+      const tagsFromDb = await getAllTags();
+      setAvailableTags(tagsFromDb);
       const bases = await getBaseIngredients();
       setBaseIngredients(bases);
     };

--- a/constants/IngredientTags.ts
+++ b/constants/IngredientTags.ts
@@ -17,15 +17,17 @@ export const TAG_COLORS = [
   "#a8a8a8", // 15
 ];
 
-export const INGREDIENT_TAGS = [
-  { id: 1, name: "strong alcohol", color: TAG_COLORS[0] },
-  { id: 2, name: "soft alcohol", color: TAG_COLORS[1] },
-  { id: 3, name: "beverage", color: TAG_COLORS[3] },
-  { id: 4, name: "syrup", color: TAG_COLORS[13] },
-  { id: 5, name: "juice", color: TAG_COLORS[10] },
-  { id: 6, name: "fruit", color: TAG_COLORS[9] },
-  { id: 7, name: "herb", color: TAG_COLORS[8] },
-  { id: 8, name: "spice", color: TAG_COLORS[14] },
-  { id: 9, name: "dairy", color: TAG_COLORS[6] },
-  { id: 10, name: "other", color: TAG_COLORS[15] },
+import type { IngredientTag } from '@/storage/ingredientTagsStorage';
+
+export const INGREDIENT_TAGS: IngredientTag[] = [
+  { id: 1, name: 'strong alcohol', color: TAG_COLORS[0], base: true },
+  { id: 2, name: 'soft alcohol', color: TAG_COLORS[1], base: true },
+  { id: 3, name: 'beverage', color: TAG_COLORS[3], base: true },
+  { id: 4, name: 'syrup', color: TAG_COLORS[13], base: true },
+  { id: 5, name: 'juice', color: TAG_COLORS[10], base: true },
+  { id: 6, name: 'fruit', color: TAG_COLORS[9], base: true },
+  { id: 7, name: 'herb', color: TAG_COLORS[8], base: true },
+  { id: 8, name: 'spice', color: TAG_COLORS[14], base: true },
+  { id: 9, name: 'dairy', color: TAG_COLORS[6], base: true },
+  { id: 10, name: 'other', color: TAG_COLORS[15], base: true },
 ];

--- a/storage/ingredientTagsStorage.ts
+++ b/storage/ingredientTagsStorage.ts
@@ -1,11 +1,64 @@
+import { openDatabaseSync } from 'expo-sqlite';
+import { INGREDIENT_TAGS } from '@/constants/IngredientTags';
+
 export type IngredientTag = {
   id: number;
   name: string;
   color: string;
+  base: boolean;
 };
 
-export async function getAllTags(): Promise<IngredientTag[]> {
-  // In a full implementation this would load custom tags from persistent storage.
-  // Currently, no custom tags are stored so we simply return an empty array.
-  return [];
+const db = openDatabaseSync('ingredients.db');
+
+db.execSync(
+  `CREATE TABLE IF NOT EXISTS ingredientTags (
+    id INTEGER PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    color TEXT NOT NULL,
+    base INTEGER NOT NULL
+  );`
+);
+
+void (async () => {
+  for (const tag of INGREDIENT_TAGS) {
+    await db.runAsync(
+      'INSERT OR IGNORE INTO ingredientTags (id, name, color, base) VALUES (?, ?, ?, ?)',
+      tag.id,
+      tag.name,
+      tag.color,
+      tag.base ? 1 : 0
+    );
+  }
+})();
+
+type IngredientTagRow = {
+  id: number;
+  name: string;
+  color: string;
+  base: number;
+};
+
+function mapRow(row: IngredientTagRow): IngredientTag {
+  return {
+    id: row.id,
+    name: row.name,
+    color: row.color,
+    base: row.base === 1,
+  };
 }
+
+export async function getAllTags(): Promise<IngredientTag[]> {
+  const rows = await db.getAllAsync<IngredientTagRow>('SELECT * FROM ingredientTags');
+  return rows.map(mapRow);
+}
+
+export async function addTag(tag: IngredientTag): Promise<void> {
+  await db.runAsync(
+    'INSERT INTO ingredientTags (id, name, color, base) VALUES (?, ?, ?, ?)',
+    tag.id,
+    tag.name,
+    tag.color,
+    tag.base ? 1 : 0
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `base` flag to default ingredient tags
- store ingredient tags in SQLite and load them from there
- fetch tags from DB in add ingredient screen

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aee1bc44f083269c8a108516366381