### PR TITLE
Preselect 'other' tag on ingredient creation

### DIFF
--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -41,6 +41,10 @@ export default function AddIngredientScreen() {
     const load = async () => {
       const tagsFromDb = await getAllTags();
       setAvailableTags(tagsFromDb);
+      const otherTag = tagsFromDb.find((t) => t.name === 'other');
+      if (otherTag) {
+        setTags([otherTag]);
+      }
       const bases = await getBaseIngredients();
       setBaseIngredients(bases);
     };


### PR DESCRIPTION
## Summary
- preselect the `other` tag when adding a new ingredient

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aee6bca9808326ab4be8e425815a0a