### PR TITLE
feat: add ingredient details screen

### DIFF
--- a/app/(tabs)/ingredients/all.tsx
+++ b/app/(tabs)/ingredients/all.tsx
@@ -47,8 +47,8 @@ export default function AllIngredientsScreen() {
       tags={item.tags}
       usageCount={0}
       showMake={false}
-      inBar={false}
-      inShoppingList={false}
+      inBar={item.inBar}
+      inShoppingList={item.inShoppingList}
       baseIngredientId={item.baseIngredientId}
       onPress={() => router.push(`/ingredient/${item.id}`)}
     />

--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -130,7 +130,11 @@ export default function AddIngredientScreen() {
           onPress={pickImage}
         >
           {photoUri ? (
-            <Image source={{ uri: photoUri }} style={styles.image} />
+            <Image
+              source={{ uri: photoUri }}
+              style={styles.image}
+              resizeMode="contain"
+            />
           ) : (
             <Text
               style={[styles.imagePlaceholder, { color: theme.colors.onSurfaceVariant }]}
@@ -355,7 +359,7 @@ const styles = StyleSheet.create({
   image: {
     width: IMAGE_SIZE,
     height: IMAGE_SIZE,
-    resizeMode: 'cover',
+    resizeMode: 'contain',
   },
   imagePlaceholder: {
     textAlign: 'center',

--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -1,7 +1,6 @@
 import * as ImagePicker from 'expo-image-picker';
 import React, { useEffect, useState } from 'react';
 import {
-  Alert,
   Image,
   KeyboardAvoidingView,
   Modal,
@@ -17,6 +16,7 @@ import {
 import { Stack, useRouter } from 'expo-router';
 import { useTheme } from 'react-native-paper';
 import IngredientHeader from '@/components/IngredientHeader';
+import ConfirmDialog from '@/components/ConfirmDialog';
 
 import {
   addIngredient,
@@ -37,6 +37,9 @@ export default function AddIngredientScreen() {
   const [baseIngredients, setBaseIngredients] = useState<Ingredient[]>([]);
   const [baseSearch, setBaseSearch] = useState('');
   const [baseModalVisible, setBaseModalVisible] = useState(false);
+  const [alert, setAlert] = useState<{ title: string; message: string } | null>(
+    null
+  );
 
   useEffect(() => {
     const load = async () => {
@@ -63,7 +66,10 @@ export default function AddIngredientScreen() {
   const pickImage = async () => {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
-      Alert.alert('Permission required', 'Allow access to media library');
+      setAlert({
+        title: 'Permission required',
+        message: 'Allow access to media library',
+      });
       return;
     }
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -77,7 +83,7 @@ export default function AddIngredientScreen() {
 
   const handleSave = async () => {
     if (!name.trim()) {
-      Alert.alert('Please enter a name for the ingredient.');
+      setAlert({ title: '', message: 'Please enter a name for the ingredient.' });
       return;
     }
     const id = Date.now();
@@ -240,6 +246,13 @@ export default function AddIngredientScreen() {
           <Text style={[styles.saveText, { color: theme.colors.onPrimary }]}>Save Ingredient</Text>
         </TouchableOpacity>
       </ScrollView>
+
+      <ConfirmDialog
+        visible={alert !== null}
+        title={alert?.title ?? ''}
+        message={alert?.message ?? ''}
+        onConfirm={() => setAlert(null)}
+      />
 
       <Modal visible={baseModalVisible} animationType="slide">
         <View

--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -16,7 +16,7 @@ import {
 
 import { Stack, useRouter } from 'expo-router';
 import { useTheme } from 'react-native-paper';
-import AddIngredientHeader from '@/components/AddIngredientHeader';
+import IngredientHeader from '@/components/IngredientHeader';
 
 import {
   addIngredient,
@@ -93,7 +93,9 @@ export default function AddIngredientScreen() {
   };
   return (
     <>
-      <Stack.Screen options={{ header: () => <AddIngredientHeader /> }} />
+      <Stack.Screen
+        options={{ header: () => <IngredientHeader title="Add ingredient" /> }}
+      />
       <KeyboardAvoidingView
         style={{ flex: 1 }}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}

--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -126,7 +126,7 @@ export default function AddIngredientScreen() {
 
         <Text style={[styles.label, { color: theme.colors.onSurface }]}>Photo:</Text>
         <TouchableOpacity
-          style={[styles.imageButton, { backgroundColor: theme.colors.surface }]}
+          style={[styles.imageButton, { backgroundColor: photoUri ? theme.colors.surface : theme.colors.placeholder }]}
           onPress={pickImage}
         >
           {photoUri ? (
@@ -198,7 +198,7 @@ export default function AddIngredientScreen() {
                   style={[
                     styles.baseFieldImage,
                     styles.baseImagePlaceholder,
-                    { backgroundColor: theme.colors.surfaceVariant },
+                    { backgroundColor: theme.colors.placeholder },
                   ]}
                 />
               )}
@@ -274,7 +274,7 @@ export default function AddIngredientScreen() {
                 style={[
                   styles.baseImage,
                   styles.baseImagePlaceholder,
-                  { backgroundColor: theme.colors.surfaceVariant },
+                  { backgroundColor: theme.colors.placeholder },
                 ]}
               />
               <Text style={[styles.baseName, { color: theme.colors.onSurface }]}>None</Text>
@@ -300,7 +300,7 @@ export default function AddIngredientScreen() {
                       style={[
                         styles.baseImage,
                         styles.baseImagePlaceholder,
-                        { backgroundColor: theme.colors.surfaceVariant },
+                        { backgroundColor: theme.colors.placeholder },
                       ]}
                     />
                   )}

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -9,6 +9,8 @@ import {
   getIngredientById,
   getBrandedIngredients,
   unlinkBaseIngredient,
+  setIngredientInBar,
+  setIngredientInShoppingList,
   type Ingredient,
 } from '@/storage/ingredientsStorage';
 
@@ -53,6 +55,22 @@ export default function IngredientViewScreen() {
     }
   };
 
+  const handleToggleInBar = async () => {
+    if (ingredient) {
+      const newValue = !ingredient.inBar;
+      await setIngredientInBar(ingredient.id, newValue);
+      setIngredient({ ...ingredient, inBar: newValue });
+    }
+  };
+
+  const handleToggleShoppingList = async () => {
+    if (ingredient) {
+      const newValue = !ingredient.inShoppingList;
+      await setIngredientInShoppingList(ingredient.id, newValue);
+      setIngredient({ ...ingredient, inShoppingList: newValue });
+    }
+  };
+
   if (!ingredient) {
     return (
       <View style={[styles.loading, { backgroundColor: theme.colors.background }]}>
@@ -90,6 +108,35 @@ export default function IngredientViewScreen() {
             <Text style={[styles.noImageText, { color: theme.colors.onSurfaceVariant }]}>No image</Text>
           </View>
         )}
+        <View style={styles.actionsRow}>
+          <TouchableOpacity onPress={handleToggleInBar}>
+            <MaterialIcons
+              name={ingredient.inBar ? 'check-box' : 'check-box-outline-blank'}
+              size={24}
+              color={
+                ingredient.inBar
+                  ? theme.colors.primary
+                  : theme.colors.onSurfaceVariant
+              }
+            />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.shoppingIcon}
+            onPress={handleToggleShoppingList}
+          >
+            <MaterialIcons
+              name={
+                ingredient.inShoppingList ? 'shopping-cart' : 'add-shopping-cart'
+              }
+              size={24}
+              color={
+                ingredient.inShoppingList
+                  ? theme.colors.primary
+                  : theme.colors.onSurfaceVariant
+              }
+            />
+          </TouchableOpacity>
+        </View>
         {ingredient.tags.length > 0 && (
           <View style={styles.tagContainer}>
             {ingredient.tags.map((tag) => (
@@ -138,7 +185,7 @@ export default function IngredientViewScreen() {
             </TouchableOpacity>
           </View>
         )}
-        {!ingredient.baseIngredientId && (
+        {!ingredient.baseIngredientId && brandedIngredients.length > 0 && (
           <View style={styles.baseSection}>
             <Text style={[styles.baseLabel, { color: theme.colors.onSurface }]}>Branded ingredients:</Text>
             {brandedIngredients.map((b) => (
@@ -276,5 +323,13 @@ const styles = StyleSheet.create({
   },
   unlinkButton: {
     padding: 8,
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    marginTop: 8,
+  },
+  shoppingIcon: {
+    marginLeft: 16,
   },
 });

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -232,52 +232,62 @@ export default function IngredientViewScreen() {
         {!ingredient.baseIngredientId && brandedIngredients.length > 0 && (
           <View style={styles.baseSection}>
             <Text style={[styles.baseLabel, { color: theme.colors.onSurface }]}>Branded ingredients:</Text>
-            {brandedIngredients.map((b) => (
-              <TouchableOpacity
-                key={b.id}
-                style={[styles.brandedRow, { borderColor: theme.colors.outline }]}
-                onPress={() => router.push(`/ingredient/${b.id}`)}
-              >
-                <View style={styles.baseContainer}>
-                  {b.photoUri ? (
-                    <Image
-                      source={{ uri: b.photoUri }}
-                      style={styles.baseImage}
-                      resizeMode="contain"
+            <View
+              style={[styles.brandedBlock, { borderColor: theme.colors.outline }]}
+            >
+              {brandedIngredients.map((b, idx) => (
+                <TouchableOpacity
+                  key={b.id}
+                  style={[
+                    styles.brandedItemRow,
+                    idx < brandedIngredients.length - 1 && {
+                      borderBottomWidth: 1,
+                      borderColor: theme.colors.outline,
+                    },
+                  ]}
+                  onPress={() => router.push(`/ingredient/${b.id}`)}
+                >
+                  <View style={styles.baseContainer}>
+                    {b.photoUri ? (
+                      <Image
+                        source={{ uri: b.photoUri }}
+                        style={styles.baseImage}
+                        resizeMode="contain"
+                      />
+                    ) : (
+                      <View
+                        style={[
+                          styles.baseImage,
+                          styles.baseImagePlaceholder,
+                          { backgroundColor: theme.colors.placeholder },
+                        ]}
+                      />
+                    )}
+                    <Text style={[styles.baseName, { color: theme.colors.onSurface }]}>
+                      {b.name}
+                    </Text>
+                  </View>
+                  <View style={styles.rowRight}>
+                    <TouchableOpacity
+                      style={styles.unlinkButton}
+                      onPress={(e) => {
+                        e.stopPropagation();
+                        handleUnlinkBranded(b);
+                      }}
+                    >
+                      <MaterialIcons name="link-off" size={20} color={theme.colors.error} />
+                    </TouchableOpacity>
+                    <MaterialIcons
+                      name="chevron-right"
+                      size={20}
+                      color={theme.colors.onSurfaceVariant}
+                      style={styles.arrowIcon}
                     />
-                  ) : (
-                    <View
-                      style={[
-                        styles.baseImage,
-                        styles.baseImagePlaceholder,
-                        { backgroundColor: theme.colors.placeholder },
-                      ]}
-                    />
-                  )}
-                  <Text style={[styles.baseName, { color: theme.colors.onSurface }]}> 
-                    {b.name}
-                  </Text>
-                </View>
-                <View style={styles.rowRight}>
-                  <TouchableOpacity
-                    style={styles.unlinkButton}
-                    onPress={(e) => {
-                      e.stopPropagation();
-                      handleUnlinkBranded(b);
-                    }}
-                  >
-                    <MaterialIcons name="link-off" size={20} color={theme.colors.error} />
-                  </TouchableOpacity>
-                  <MaterialIcons
-                    name="chevron-right"
-                    size={20}
-                    color={theme.colors.onSurfaceVariant}
-                    style={styles.arrowIcon}
-                  />
-                </View>
-              </TouchableOpacity>
-            ))}
-        </View>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
         )}
         {ingredient.description ? (
           <Text style={[styles.description, { color: theme.colors.onSurface }]}>
@@ -375,6 +385,17 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 8,
     marginBottom: 8,
+  },
+  brandedBlock: {
+    borderWidth: 1,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  brandedItemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 8,
   },
   rowRight: {
     flexDirection: 'row',

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -53,20 +53,28 @@ export default function IngredientViewScreen() {
           { backgroundColor: theme.colors.background },
         ]}
       >
-        {ingredient.photoUri && (
-          <Image
-            source={{ uri: ingredient.photoUri }}
-            style={[styles.image]}
-          />
-        )}
         <Text style={[styles.name, { color: theme.colors.onSurface }]}> 
           {ingredient.name}
         </Text>
-        {ingredient.description ? (
-          <Text style={[styles.description, { color: theme.colors.onSurface }]}> 
-            {ingredient.description}
-          </Text>
-        ) : null}
+        {ingredient.photoUri ? (
+          <Image
+            source={{ uri: ingredient.photoUri }}
+            style={styles.image}
+          />
+        ) : (
+          <View
+            style={[
+              styles.imagePlaceholder,
+              { backgroundColor: theme.colors.surfaceVariant },
+            ]}
+          >
+            <Text
+              style={[styles.noImageText, { color: theme.colors.onSurfaceVariant }]}
+            >
+              No image
+            </Text>
+          </View>
+        )}
         {ingredient.tags.length > 0 && (
           <View style={styles.tagContainer}>
             {ingredient.tags.map((tag) => (
@@ -80,18 +88,38 @@ export default function IngredientViewScreen() {
           </View>
         )}
         {baseIngredient && (
-          <View style={styles.baseContainer}>
-            {baseIngredient.photoUri && (
-              <Image
-                source={{ uri: baseIngredient.photoUri }}
-                style={styles.baseImage}
-              />
-            )}
-            <Text style={[styles.baseName, { color: theme.colors.onSurface }]}>
-              {baseIngredient.name}
+          <View style={styles.baseSection}>
+            <Text style={[styles.baseLabel, { color: theme.colors.onSurface }]}> 
+              Base ingredient:
             </Text>
+            <View style={styles.baseContainer}>
+              {baseIngredient.photoUri ? (
+                <Image
+                  source={{ uri: baseIngredient.photoUri }}
+                  style={styles.baseImage}
+                />
+              ) : (
+                <View
+                  style={[
+                    styles.baseImage,
+                    styles.baseImagePlaceholder,
+                    { backgroundColor: theme.colors.surfaceVariant },
+                  ]}
+                />
+              )}
+              <Text
+                style={[styles.baseName, { color: theme.colors.onSurface }]}
+              >
+                {baseIngredient.name}
+              </Text>
+            </View>
           </View>
         )}
+        {ingredient.description ? (
+          <Text style={[styles.description, { color: theme.colors.onSurface }]}> 
+            {ingredient.description}
+          </Text>
+        ) : null}
       </ScrollView>
     </>
   );
@@ -114,7 +142,19 @@ const styles = StyleSheet.create({
     height: IMAGE_SIZE,
     borderRadius: 8,
     alignSelf: 'center',
-    marginBottom: 16,
+    marginTop: 16,
+  },
+  imagePlaceholder: {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    borderRadius: 8,
+    alignSelf: 'center',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 16,
+  },
+  noImageText: {
+    fontSize: 14,
   },
   name: {
     fontSize: 24,
@@ -122,12 +162,12 @@ const styles = StyleSheet.create({
   },
   description: {
     fontSize: 16,
-    marginTop: 8,
+    marginTop: 24,
   },
   tagContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginTop: 16,
+    marginTop: 24,
   },
   tag: {
     paddingHorizontal: 10,
@@ -139,16 +179,25 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontWeight: 'bold',
   },
+  baseSection: {
+    marginTop: 24,
+  },
+  baseLabel: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
   baseContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: 24,
   },
   baseImage: {
     width: BASE_IMAGE_SIZE,
     height: BASE_IMAGE_SIZE,
     borderRadius: 8,
     marginRight: 12,
+  },
+  baseImagePlaceholder: {
+    borderRadius: 8,
   },
   baseName: {
     fontSize: 16,

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -102,11 +102,11 @@ export default function IngredientViewScreen() {
         {ingredient.baseIngredientId && baseIngredient && (
           <View style={styles.baseSection}>
             <Text style={[styles.baseLabel, { color: theme.colors.onSurface }]}>Base ingredient:</Text>
-            <View style={styles.brandedRow}>
-              <TouchableOpacity
-                style={styles.baseContainer}
-                onPress={() => router.push(`/ingredient/${baseIngredient.id}`)}
-              >
+            <TouchableOpacity
+              style={styles.brandedRow}
+              onPress={() => router.push(`/ingredient/${baseIngredient.id}`)}
+            >
+              <View style={styles.baseContainer}>
                 {baseIngredient.photoUri ? (
                   <Image
                     source={{ uri: baseIngredient.photoUri }}
@@ -125,22 +125,29 @@ export default function IngredientViewScreen() {
                 <Text style={[styles.baseName, { color: theme.colors.onSurface }]}> 
                   {baseIngredient.name}
                 </Text>
+              </View>
+              <TouchableOpacity
+                style={styles.unlinkButton}
+                onPress={(e) => {
+                  e.stopPropagation();
+                  handleUnlinkBase();
+                }}
+              >
+                <MaterialIcons name="link-off" size={20} color={theme.colors.error} />
               </TouchableOpacity>
-              <TouchableOpacity style={styles.unlinkButton} onPress={handleUnlinkBase}>
-                <MaterialIcons name="link-off" size={20} color={theme.colors.primary} />
-              </TouchableOpacity>
-            </View>
+            </TouchableOpacity>
           </View>
         )}
         {!ingredient.baseIngredientId && (
           <View style={styles.baseSection}>
             <Text style={[styles.baseLabel, { color: theme.colors.onSurface }]}>Branded ingredients:</Text>
             {brandedIngredients.map((b) => (
-              <View key={b.id} style={styles.brandedRow}>
-                <TouchableOpacity
-                  style={styles.baseContainer}
-                  onPress={() => router.push(`/ingredient/${b.id}`)}
-                >
+              <TouchableOpacity
+                key={b.id}
+                style={styles.brandedRow}
+                onPress={() => router.push(`/ingredient/${b.id}`)}
+              >
+                <View style={styles.baseContainer}>
                   {b.photoUri ? (
                     <Image
                       source={{ uri: b.photoUri }}
@@ -159,14 +166,17 @@ export default function IngredientViewScreen() {
                   <Text style={[styles.baseName, { color: theme.colors.onSurface }]}> 
                     {b.name}
                   </Text>
-                </TouchableOpacity>
+                </View>
                 <TouchableOpacity
                   style={styles.unlinkButton}
-                  onPress={() => handleUnlinkBranded(b.id)}
+                  onPress={(e) => {
+                    e.stopPropagation();
+                    handleUnlinkBranded(b.id);
+                  }}
                 >
-                  <MaterialIcons name="link-off" size={20} color={theme.colors.primary} />
+                  <MaterialIcons name="link-off" size={20} color={theme.colors.error} />
                 </TouchableOpacity>
-              </View>
+              </TouchableOpacity>
             ))}
         </View>
         )}

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -1,6 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { ScrollView, View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
+import {
+  ScrollView,
+  View,
+  Text,
+  Image,
+  StyleSheet,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
 import { useTheme } from 'react-native-paper';
 import { MaterialIcons } from '@expo/vector-icons';
 
@@ -41,17 +49,43 @@ export default function IngredientViewScreen() {
     load();
   }, [id]);
 
-  const handleUnlinkBranded = async (brandedId: number) => {
-    await unlinkBaseIngredient(brandedId);
-    setBrandedIngredients((prev) => prev.filter((b) => b.id !== brandedId));
+  const handleUnlinkBranded = (branded: Ingredient) => {
+    Alert.alert(
+      'Unlink',
+      `Remove link for "${branded.name}" from this base ingredient?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'OK',
+          onPress: async () => {
+            await unlinkBaseIngredient(branded.id);
+            setBrandedIngredients((prev) =>
+              prev.filter((b) => b.id !== branded.id)
+            );
+          },
+        },
+      ]
+    );
   };
 
-  const handleUnlinkBase = async () => {
-    if (ingredient) {
-      await unlinkBaseIngredient(ingredient.id);
-      setIngredient({ ...ingredient, baseIngredientId: null });
-      setBaseIngredient(null);
-      setBrandedIngredients([]);
+  const handleUnlinkBase = () => {
+    if (ingredient && baseIngredient) {
+      Alert.alert(
+        'Unlink',
+        `Remove link to base ingredient ${baseIngredient.name}?`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'OK',
+            onPress: async () => {
+              await unlinkBaseIngredient(ingredient.id);
+              setIngredient({ ...ingredient, baseIngredientId: null });
+              setBaseIngredient(null);
+              setBrandedIngredients([]);
+            },
+          },
+        ]
+      );
     }
   };
 
@@ -152,7 +186,7 @@ export default function IngredientViewScreen() {
           <View style={styles.baseSection}>
             <Text style={[styles.baseLabel, { color: theme.colors.onSurface }]}>Base ingredient:</Text>
             <TouchableOpacity
-              style={styles.brandedRow}
+              style={[styles.brandedRow, { borderColor: theme.colors.outline }]}
               onPress={() => router.push(`/ingredient/${baseIngredient.id}`)}
             >
               <View style={styles.baseContainer}>
@@ -175,15 +209,23 @@ export default function IngredientViewScreen() {
                   {baseIngredient.name}
                 </Text>
               </View>
-              <TouchableOpacity
-                style={styles.unlinkButton}
-                onPress={(e) => {
-                  e.stopPropagation();
-                  handleUnlinkBase();
-                }}
-              >
-                <MaterialIcons name="link-off" size={20} color={theme.colors.error} />
-              </TouchableOpacity>
+              <View style={styles.rowRight}>
+                <TouchableOpacity
+                  style={styles.unlinkButton}
+                  onPress={(e) => {
+                    e.stopPropagation();
+                    handleUnlinkBase();
+                  }}
+                >
+                  <MaterialIcons name="link-off" size={20} color={theme.colors.error} />
+                </TouchableOpacity>
+                <MaterialIcons
+                  name="chevron-right"
+                  size={20}
+                  color={theme.colors.onSurfaceVariant}
+                  style={styles.arrowIcon}
+                />
+              </View>
             </TouchableOpacity>
           </View>
         )}
@@ -193,7 +235,7 @@ export default function IngredientViewScreen() {
             {brandedIngredients.map((b) => (
               <TouchableOpacity
                 key={b.id}
-                style={styles.brandedRow}
+                style={[styles.brandedRow, { borderColor: theme.colors.outline }]}
                 onPress={() => router.push(`/ingredient/${b.id}`)}
               >
                 <View style={styles.baseContainer}>
@@ -216,15 +258,23 @@ export default function IngredientViewScreen() {
                     {b.name}
                   </Text>
                 </View>
-                <TouchableOpacity
-                  style={styles.unlinkButton}
-                  onPress={(e) => {
-                    e.stopPropagation();
-                    handleUnlinkBranded(b.id);
-                  }}
-                >
-                  <MaterialIcons name="link-off" size={20} color={theme.colors.error} />
-                </TouchableOpacity>
+                <View style={styles.rowRight}>
+                  <TouchableOpacity
+                    style={styles.unlinkButton}
+                    onPress={(e) => {
+                      e.stopPropagation();
+                      handleUnlinkBranded(b);
+                    }}
+                  >
+                    <MaterialIcons name="link-off" size={20} color={theme.colors.error} />
+                  </TouchableOpacity>
+                  <MaterialIcons
+                    name="chevron-right"
+                    size={20}
+                    color={theme.colors.onSurfaceVariant}
+                    style={styles.arrowIcon}
+                  />
+                </View>
               </TouchableOpacity>
             ))}
         </View>
@@ -321,7 +371,17 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+    padding: 8,
+    borderWidth: 1,
+    borderRadius: 8,
     marginBottom: 8,
+  },
+  rowRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  arrowIcon: {
+    marginLeft: 4,
   },
   unlinkButton: {
     padding: 8,

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -1,0 +1,156 @@
+import React, { useEffect, useState } from 'react';
+import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
+import { ScrollView, View, Text, Image, StyleSheet } from 'react-native';
+import { useTheme } from 'react-native-paper';
+
+import IngredientHeader from '@/components/IngredientHeader';
+import { getIngredientById, type Ingredient } from '@/storage/ingredientsStorage';
+
+export default function IngredientViewScreen() {
+  const { id } = useLocalSearchParams();
+  const theme = useTheme();
+  const router = useRouter();
+  const [ingredient, setIngredient] = useState<Ingredient | null>(null);
+  const [baseIngredient, setBaseIngredient] = useState<Ingredient | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (typeof id === 'string') {
+        const ing = await getIngredientById(Number(id));
+        setIngredient(ing);
+        if (ing?.baseIngredientId) {
+          const base = await getIngredientById(ing.baseIngredientId);
+          setBaseIngredient(base);
+        }
+      }
+    };
+    load();
+  }, [id]);
+
+  if (!ingredient) {
+    return (
+      <View style={[styles.loading, { backgroundColor: theme.colors.background }]}> 
+        <Text>Loading...</Text>
+      </View>
+    );
+  }
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          header: () => (
+            <IngredientHeader
+              title="Edit ingredient"
+              onEdit={() => router.push(`/add-ingredient?id=${ingredient.id}`)}
+            />
+          ),
+        }}
+      />
+      <ScrollView
+        contentContainerStyle={[
+          styles.container,
+          { backgroundColor: theme.colors.background },
+        ]}
+      >
+        {ingredient.photoUri && (
+          <Image
+            source={{ uri: ingredient.photoUri }}
+            style={[styles.image]}
+          />
+        )}
+        <Text style={[styles.name, { color: theme.colors.onSurface }]}> 
+          {ingredient.name}
+        </Text>
+        {ingredient.description ? (
+          <Text style={[styles.description, { color: theme.colors.onSurface }]}> 
+            {ingredient.description}
+          </Text>
+        ) : null}
+        {ingredient.tags.length > 0 && (
+          <View style={styles.tagContainer}>
+            {ingredient.tags.map((tag) => (
+              <View
+                key={tag.id}
+                style={[styles.tag, { backgroundColor: tag.color }]}
+              >
+                <Text style={styles.tagText}>{tag.name}</Text>
+              </View>
+            ))}
+          </View>
+        )}
+        {baseIngredient && (
+          <View style={styles.baseContainer}>
+            {baseIngredient.photoUri && (
+              <Image
+                source={{ uri: baseIngredient.photoUri }}
+                style={styles.baseImage}
+              />
+            )}
+            <Text style={[styles.baseName, { color: theme.colors.onSurface }]}>
+              {baseIngredient.name}
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+    </>
+  );
+}
+
+const IMAGE_SIZE = 150;
+const BASE_IMAGE_SIZE = 40;
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 24,
+  },
+  loading: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  image: {
+    width: IMAGE_SIZE,
+    height: IMAGE_SIZE,
+    borderRadius: 8,
+    alignSelf: 'center',
+    marginBottom: 16,
+  },
+  name: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  description: {
+    fontSize: 16,
+    marginTop: 8,
+  },
+  tagContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 16,
+  },
+  tag: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 16,
+    margin: 4,
+  },
+  tagText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+  baseContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 24,
+  },
+  baseImage: {
+    width: BASE_IMAGE_SIZE,
+    height: BASE_IMAGE_SIZE,
+    borderRadius: 8,
+    marginRight: 12,
+  },
+  baseName: {
+    fontSize: 16,
+  },
+});

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { ScrollView, View, Text, Image, StyleSheet, TouchableOpacity } from 'react-native';
 import { useTheme } from 'react-native-paper';
+import { MaterialIcons } from '@expo/vector-icons';
 
 import IngredientHeader from '@/components/IngredientHeader';
 import {
@@ -38,9 +39,18 @@ export default function IngredientViewScreen() {
     load();
   }, [id]);
 
-  const handleUnlink = async (brandedId: number) => {
+  const handleUnlinkBranded = async (brandedId: number) => {
     await unlinkBaseIngredient(brandedId);
     setBrandedIngredients((prev) => prev.filter((b) => b.id !== brandedId));
+  };
+
+  const handleUnlinkBase = async () => {
+    if (ingredient) {
+      await unlinkBaseIngredient(ingredient.id);
+      setIngredient({ ...ingredient, baseIngredientId: null });
+      setBaseIngredient(null);
+      setBrandedIngredients([]);
+    }
   };
 
   if (!ingredient) {
@@ -75,7 +85,7 @@ export default function IngredientViewScreen() {
           />
         ) : (
           <View
-            style={[styles.imagePlaceholder, { backgroundColor: theme.colors.surfaceVariant }]}
+            style={[styles.imagePlaceholder, { backgroundColor: theme.colors.placeholder }]}
           >
             <Text style={[styles.noImageText, { color: theme.colors.onSurfaceVariant }]}>No image</Text>
           </View>
@@ -92,29 +102,34 @@ export default function IngredientViewScreen() {
         {ingredient.baseIngredientId && baseIngredient && (
           <View style={styles.baseSection}>
             <Text style={[styles.baseLabel, { color: theme.colors.onSurface }]}>Base ingredient:</Text>
-            <TouchableOpacity
-              style={styles.baseContainer}
-              onPress={() => router.push(`/ingredient/${baseIngredient.id}`)}
-            >
-              {baseIngredient.photoUri ? (
-                <Image
-                  source={{ uri: baseIngredient.photoUri }}
-                  style={styles.baseImage}
-                  resizeMode="contain"
-                />
-              ) : (
-                <View
-                  style={[
-                    styles.baseImage,
-                    styles.baseImagePlaceholder,
-                    { backgroundColor: theme.colors.surfaceVariant },
-                  ]}
-                />
-              )}
-              <Text style={[styles.baseName, { color: theme.colors.onSurface }]}>
-                {baseIngredient.name}
-              </Text>
-            </TouchableOpacity>
+            <View style={styles.brandedRow}>
+              <TouchableOpacity
+                style={styles.baseContainer}
+                onPress={() => router.push(`/ingredient/${baseIngredient.id}`)}
+              >
+                {baseIngredient.photoUri ? (
+                  <Image
+                    source={{ uri: baseIngredient.photoUri }}
+                    style={styles.baseImage}
+                    resizeMode="contain"
+                  />
+                ) : (
+                  <View
+                    style={[
+                      styles.baseImage,
+                      styles.baseImagePlaceholder,
+                      { backgroundColor: theme.colors.placeholder },
+                    ]}
+                  />
+                )}
+                <Text style={[styles.baseName, { color: theme.colors.onSurface }]}> 
+                  {baseIngredient.name}
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.unlinkButton} onPress={handleUnlinkBase}>
+                <MaterialIcons name="link-off" size={20} color={theme.colors.primary} />
+              </TouchableOpacity>
+            </View>
           </View>
         )}
         {!ingredient.baseIngredientId && (
@@ -137,23 +152,23 @@ export default function IngredientViewScreen() {
                       style={[
                         styles.baseImage,
                         styles.baseImagePlaceholder,
-                        { backgroundColor: theme.colors.surfaceVariant },
+                        { backgroundColor: theme.colors.placeholder },
                       ]}
                     />
                   )}
-                  <Text style={[styles.baseName, { color: theme.colors.onSurface }]}>
+                  <Text style={[styles.baseName, { color: theme.colors.onSurface }]}> 
                     {b.name}
                   </Text>
                 </TouchableOpacity>
                 <TouchableOpacity
                   style={styles.unlinkButton}
-                  onPress={() => handleUnlink(b.id)}
+                  onPress={() => handleUnlinkBranded(b.id)}
                 >
-                  <Text style={[styles.unlinkText, { color: theme.colors.primary }]}>Unlink</Text>
+                  <MaterialIcons name="link-off" size={20} color={theme.colors.primary} />
                 </TouchableOpacity>
               </View>
             ))}
-          </View>
+        </View>
         )}
         {ingredient.description ? (
           <Text style={[styles.description, { color: theme.colors.onSurface }]}>
@@ -225,6 +240,7 @@ const styles = StyleSheet.create({
   baseLabel: {
     fontSize: 16,
     marginBottom: 8,
+    fontWeight: 'bold',
   },
   baseContainer: {
     flexDirection: 'row',
@@ -250,8 +266,5 @@ const styles = StyleSheet.create({
   },
   unlinkButton: {
     padding: 8,
-  },
-  unlinkText: {
-    fontSize: 14,
   },
 });

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -109,21 +109,7 @@ export default function IngredientViewScreen() {
           </View>
         )}
         <View style={styles.actionsRow}>
-          <TouchableOpacity onPress={handleToggleInBar}>
-            <MaterialIcons
-              name={ingredient.inBar ? 'check-box' : 'check-box-outline-blank'}
-              size={24}
-              color={
-                ingredient.inBar
-                  ? theme.colors.primary
-                  : theme.colors.onSurfaceVariant
-              }
-            />
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={styles.shoppingIcon}
-            onPress={handleToggleShoppingList}
-          >
+          <TouchableOpacity onPress={handleToggleShoppingList}>
             <MaterialIcons
               name={
                 ingredient.inShoppingList ? 'shopping-cart' : 'add-shopping-cart'
@@ -131,6 +117,22 @@ export default function IngredientViewScreen() {
               size={24}
               color={
                 ingredient.inShoppingList
+                  ? theme.colors.primary
+                  : theme.colors.onSurfaceVariant
+              }
+            />
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={styles.checkboxIcon}
+            onPress={handleToggleInBar}
+          >
+            <MaterialIcons
+              name={
+                ingredient.inBar ? 'check-circle' : 'radio-button-unchecked'
+              }
+              size={24}
+              color={
+                ingredient.inBar
                   ? theme.colors.primary
                   : theme.colors.onSurfaceVariant
               }
@@ -329,7 +331,7 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     marginTop: 8,
   },
-  shoppingIcon: {
+  checkboxIcon: {
     marginLeft: 16,
   },
 });

--- a/components/ConfirmDialog.tsx
+++ b/components/ConfirmDialog.tsx
@@ -24,7 +24,11 @@ export default function ConfirmDialog({
   const theme = useTheme();
   return (
     <Portal>
-      <Dialog visible={visible} onDismiss={onCancel} style={styles.dialog}>
+      <Dialog
+        visible={visible}
+        onDismiss={onCancel}
+        style={[styles.dialog, { backgroundColor: theme.colors.background }]}
+      >
         {title ? <Dialog.Title>{title}</Dialog.Title> : null}
         {message ? (
           <Dialog.Content>
@@ -33,11 +37,23 @@ export default function ConfirmDialog({
         ) : null}
         <Dialog.Actions>
           {cancelLabel && onCancel ? (
-            <Button textColor={theme.colors.onSurfaceVariant} onPress={onCancel}>
+            <Button
+              mode="outlined"
+              style={[styles.button, { borderColor: theme.colors.primary }]}
+              buttonColor={theme.colors.background}
+              textColor={theme.colors.primary}
+              onPress={onCancel}
+            >
               {cancelLabel}
             </Button>
           ) : null}
-          <Button textColor={theme.colors.primary} onPress={onConfirm}>
+          <Button
+            mode="contained"
+            style={styles.button}
+            buttonColor={theme.colors.primary}
+            textColor={theme.colors.onPrimary}
+            onPress={onConfirm}
+          >
             {confirmLabel}
           </Button>
         </Dialog.Actions>
@@ -49,6 +65,9 @@ export default function ConfirmDialog({
 const styles = StyleSheet.create({
   dialog: {
     borderRadius: 8,
+  },
+  button: {
+    borderRadius: 16,
   },
 });
 

--- a/components/ConfirmDialog.tsx
+++ b/components/ConfirmDialog.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Portal, Dialog, Button, Text, useTheme } from 'react-native-paper';
+
+interface ConfirmDialogProps {
+  visible: boolean;
+  title: string;
+  message: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+export default function ConfirmDialog({
+  visible,
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  confirmLabel = 'OK',
+  cancelLabel,
+}: ConfirmDialogProps) {
+  const theme = useTheme();
+  return (
+    <Portal>
+      <Dialog visible={visible} onDismiss={onCancel} style={styles.dialog}>
+        {title ? <Dialog.Title>{title}</Dialog.Title> : null}
+        {message ? (
+          <Dialog.Content>
+            <Text>{message}</Text>
+          </Dialog.Content>
+        ) : null}
+        <Dialog.Actions>
+          {cancelLabel && onCancel ? (
+            <Button textColor={theme.colors.onSurfaceVariant} onPress={onCancel}>
+              {cancelLabel}
+            </Button>
+          ) : null}
+          <Button textColor={theme.colors.primary} onPress={onConfirm}>
+            {confirmLabel}
+          </Button>
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
+  );
+}
+
+const styles = StyleSheet.create({
+  dialog: {
+    borderRadius: 8,
+  },
+});
+

--- a/components/ConfirmDialog.tsx
+++ b/components/ConfirmDialog.tsx
@@ -67,7 +67,7 @@ const styles = StyleSheet.create({
     borderRadius: 8,
   },
   button: {
-    borderRadius: 16,
+    borderRadius: 24,
   },
 });
 

--- a/components/GeneralMenu.tsx
+++ b/components/GeneralMenu.tsx
@@ -8,10 +8,10 @@ import {
   Text,
   ScrollView,
   TouchableOpacity,
-  Alert,
 } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 import { useTheme } from 'react-native-paper';
+import ConfirmDialog from '@/components/ConfirmDialog';
 import { Link } from 'expo-router';
 
 interface GeneralMenuProps {
@@ -25,6 +25,9 @@ const MENU_WIDTH = SCREEN_WIDTH * 0.75;
 export default function GeneralMenu({ visible, onClose }: GeneralMenuProps) {
   const theme = useTheme();
   const slideAnim = useRef(new Animated.Value(-MENU_WIDTH)).current;
+  const [alert, setAlert] = React.useState<{ title: string; message: string } | null>(
+    null
+  );
 
   useEffect(() => {
     if (visible) {
@@ -81,40 +84,41 @@ export default function GeneralMenu({ visible, onClose }: GeneralMenuProps) {
 
   const handleIngredientTags = () => {
     onClose();
-    Alert.alert('Ingredient tags', 'Tag editor not implemented');
+    setAlert({ title: 'Ingredient tags', message: 'Tag editor not implemented' });
   };
 
   const handleCocktailTags = () => {
     onClose();
-    Alert.alert('Cocktail tags', 'Tag editor not implemented');
+    setAlert({ title: 'Cocktail tags', message: 'Tag editor not implemented' });
   };
 
   const handleExportPhotos = () => {
     onClose();
-    Alert.alert('Export photos', 'Photo export not implemented');
+    setAlert({ title: 'Export photos', message: 'Photo export not implemented' });
   };
 
   const handleExportData = () => {
     onClose();
-    Alert.alert('Export data', 'Data export not implemented');
+    setAlert({ title: 'Export data', message: 'Data export not implemented' });
   };
 
   const handleImportData = () => {
     onClose();
-    Alert.alert('Import data', 'Data import not implemented');
+    setAlert({ title: 'Import data', message: 'Data import not implemented' });
   };
 
   return (
-    <Modal transparent visible={visible} animationType="none" onRequestClose={onClose}>
-      <Pressable style={styles.overlay} onPress={onClose}>
-        <Animated.View
-          style={[
-            styles.menu,
-            { width: MENU_WIDTH, transform: [{ translateX: slideAnim }] },
-          ]}
-          onStartShouldSetResponder={() => true}
-        >
-          <ScrollView style={{ marginTop: -32 }}>
+    <>
+      <Modal transparent visible={visible} animationType="none" onRequestClose={onClose}>
+        <Pressable style={styles.overlay} onPress={onClose}>
+          <Animated.View
+            style={[
+              styles.menu,
+              { width: MENU_WIDTH, transform: [{ translateX: slideAnim }] },
+            ]}
+            onStartShouldSetResponder={() => true}
+          >
+            <ScrollView style={{ marginTop: -32 }}>
             <Text style={styles.title}>Main Menu</Text>
 
             <Link href="/(tabs)/cocktails" asChild>
@@ -211,10 +215,17 @@ export default function GeneralMenu({ visible, onClose }: GeneralMenuProps) {
               />
               <Text style={styles.itemTitle}>Import data</Text>
             </TouchableOpacity>
-          </ScrollView>
-        </Animated.View>
-      </Pressable>
-    </Modal>
+            </ScrollView>
+          </Animated.View>
+        </Pressable>
+      </Modal>
+      <ConfirmDialog
+        visible={alert !== null}
+        title={alert?.title ?? ''}
+        message={alert?.message ?? ''}
+        onConfirm={() => setAlert(null)}
+      />
+    </>
   );
 }
 

--- a/components/IngredientHeader.tsx
+++ b/components/IngredientHeader.tsx
@@ -6,19 +6,28 @@ import { useRouter } from 'expo-router';
 
 const HEADER_HEIGHT = 28;
 
-export default function AddIngredientHeader() {
+type Props = {
+  title: string;
+  onEdit?: () => void;
+};
+
+export default function IngredientHeader({ title, onEdit }: Props) {
   const theme = useTheme();
   const router = useRouter();
 
   return (
-    <View style={[styles.container, { backgroundColor: theme.colors.background }]}> 
+    <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
       <TouchableOpacity onPress={() => router.back()} style={styles.iconBtn}>
         <MaterialIcons name="arrow-back" size={24} color={theme.colors.onSurface} />
       </TouchableOpacity>
-      <Text style={[styles.title, { color: theme.colors.onSurface }]}>Add ingredient</Text>
-      <TouchableOpacity onPress={() => {}} style={styles.iconBtn}>
-        <MaterialIcons name="edit" size={24} color={theme.colors.onSurface} />
-      </TouchableOpacity>
+      <Text style={[styles.title, { color: theme.colors.onSurface }]}>{title}</Text>
+      {onEdit ? (
+        <TouchableOpacity onPress={onEdit} style={styles.iconBtn}>
+          <MaterialIcons name="edit" size={24} color={theme.colors.onSurface} />
+        </TouchableOpacity>
+      ) : (
+        <View style={styles.iconBtn} />
+      )}
     </View>
   );
 }

--- a/components/IngredientHeader.tsx
+++ b/components/IngredientHeader.tsx
@@ -4,7 +4,7 @@ import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { useTheme } from 'react-native-paper';
 import { useRouter } from 'expo-router';
 
-const HEADER_HEIGHT = 28;
+const HEADER_HEIGHT = 56;
 
 type Props = {
   title: string;

--- a/components/IngredientRow.tsx
+++ b/components/IngredientRow.tsx
@@ -108,7 +108,7 @@ function IngredientRow({
               style={[
                 styles.image,
                 styles.placeholder,
-                { backgroundColor: theme.colors.surface },
+                { backgroundColor: theme.colors.placeholder },
               ]}
             >
               <Text

--- a/constants/AppTheme.ts
+++ b/constants/AppTheme.ts
@@ -30,7 +30,7 @@ export const AppTheme = {
     onSurfaceVariant: "#A1A1A1",
 
     disabled: "#CED4DA",
-    placeholder: "#EAF3F9",
+    placeholder: "#F8F9FA",
     backdrop: "rgba(0,0,0,0.4)",
   },
 };

--- a/constants/AppTheme.ts
+++ b/constants/AppTheme.ts
@@ -30,7 +30,7 @@ export const AppTheme = {
     onSurfaceVariant: "#A1A1A1",
 
     disabled: "#CED4DA",
-    placeholder: "#A1A1A1",
+    placeholder: "#EAF3F9",
     backdrop: "rgba(0,0,0,0.4)",
   },
 };

--- a/storage/ingredientsStorage.ts
+++ b/storage/ingredientsStorage.ts
@@ -85,3 +85,20 @@ export async function getIngredientById(id: number): Promise<Ingredient | null> 
   }
   return mapRowToIngredient(rows[0]);
 }
+
+export async function getBrandedIngredients(
+  baseIngredientId: number
+): Promise<Ingredient[]> {
+  const rows = await db.getAllAsync<IngredientRow>(
+    'SELECT * FROM ingredients WHERE baseIngredientId = ?',
+    baseIngredientId
+  );
+  return rows.map(mapRowToIngredient);
+}
+
+export async function unlinkBaseIngredient(ingredientId: number): Promise<void> {
+  await db.runAsync(
+    'UPDATE ingredients SET baseIngredientId = NULL WHERE id = ?',
+    ingredientId
+  );
+}

--- a/storage/ingredientsStorage.ts
+++ b/storage/ingredientsStorage.ts
@@ -74,3 +74,14 @@ export async function getAllIngredients(): Promise<Ingredient[]> {
 export async function getBaseIngredients(): Promise<Ingredient[]> {
   return queryIngredients('WHERE baseIngredientId IS NULL');
 }
+
+export async function getIngredientById(id: number): Promise<Ingredient | null> {
+  const rows = await db.getAllAsync<IngredientRow>(
+    'SELECT * FROM ingredients WHERE id = ? LIMIT 1',
+    id
+  );
+  if (rows.length === 0) {
+    return null;
+  }
+  return mapRowToIngredient(rows[0]);
+}


### PR DESCRIPTION
## Summary
- add dynamic ingredient view screen showing full info with edit header
- replace AddIngredientHeader with generic IngredientHeader
- remove edit button from add ingredient screen
- add helper to fetch ingredient by id

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aef5b1d1ec83269b4ed7ab6370b17d