### PR TITLE
Add left checkbox to ingredient list

### DIFF
--- a/app/(tabs)/ingredients/all.tsx
+++ b/app/(tabs)/ingredients/all.tsx
@@ -1,7 +1,11 @@
 import React, { useState, useCallback } from 'react';
 import { View, Text, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
-import { getAllIngredients, type Ingredient } from '@/storage/ingredientsStorage';
+import {
+  getAllIngredients,
+  setIngredientInBar,
+  type Ingredient,
+} from '@/storage/ingredientsStorage';
 import IngredientRow from '@/components/IngredientRow';
 
 export default function AllIngredientsScreen() {
@@ -39,6 +43,18 @@ export default function AllIngredientsScreen() {
     );
   }
 
+  const toggleInBar = async (id: number) => {
+    const ingredient = ingredients.find((i) => i.id === id);
+    if (!ingredient) {
+      return;
+    }
+    const updated = !ingredient.inBar;
+    setIngredients((prev) =>
+      prev.map((i) => (i.id === id ? { ...i, inBar: updated } : i))
+    );
+    await setIngredientInBar(id, updated);
+  };
+
   const renderItem = ({ item }: { item: Ingredient }) => (
     <IngredientRow
       id={item.id}
@@ -51,6 +67,7 @@ export default function AllIngredientsScreen() {
       inShoppingList={item.inShoppingList}
       baseIngredientId={item.baseIngredientId}
       onPress={() => router.push(`/ingredient/${item.id}`)}
+      onToggleInBar={toggleInBar}
     />
   );
 

--- a/components/IngredientRow.tsx
+++ b/components/IngredientRow.tsx
@@ -82,21 +82,6 @@ function IngredientRow({
             },
           ]}
         >
-        {onToggleInBar && (
-          <Pressable
-            onPress={() => onToggleInBar(id)}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            android_ripple={{ ...ripple, borderless: true }}
-            style={({ pressed }) => [styles.leftCheck, pressed && styles.pressedCheck]}
-          >
-            <MaterialIcons
-              name={inBar ? 'check-box' : 'check-box-outline-blank'}
-              size={22}
-              color={inBar ? theme.colors.primary : theme.colors.onSurfaceVariant}
-            />
-          </Pressable>
-        )}
-
         {inShoppingList && !onToggleShoppingList && !onRemove && (
           <MaterialIcons
             name="shopping-cart"
@@ -218,6 +203,21 @@ function IngredientRow({
             />
           </Pressable>
         ) : null}
+
+        {onToggleInBar && (
+          <Pressable
+            onPress={() => onToggleInBar(id)}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            android_ripple={{ ...ripple, borderless: true }}
+            style={({ pressed }) => [styles.checkButton, pressed && styles.pressedCheck]}
+          >
+            <MaterialIcons
+              name={inBar ? 'check-circle' : 'radio-button-unchecked'}
+              size={22}
+              color={inBar ? theme.colors.primary : theme.colors.onSurfaceVariant}
+            />
+          </Pressable>
+        )}
       </View>
     </View>
   );
@@ -267,7 +267,6 @@ const styles = StyleSheet.create({
   cartIcon: { position: 'absolute', bottom: 4, right: 60, zIndex: 1 },
   brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
   checkButton: { marginLeft: 8, paddingVertical: 6, paddingHorizontal: 4 },
-  leftCheck: { marginRight: 8, paddingVertical: 6, paddingHorizontal: 4 },
   pressedCheck: { opacity: 0.7, transform: [{ scale: 0.92 }] },
   removeButton: { marginLeft: 8, paddingVertical: 6, paddingHorizontal: 4 },
   pressedRemove: { opacity: 0.7, transform: [{ scale: 0.92 }] },

--- a/components/IngredientRow.tsx
+++ b/components/IngredientRow.tsx
@@ -68,20 +68,35 @@ function IngredientRow({
         highlightColor && { backgroundColor: highlightColor },
       ]}
     >
-      <View
-        style={[
-          styles.item,
-          isBranded && {
-            ...styles.brandedStripe,
-            borderLeftColor: theme.colors.primary,
-          },
-          !inBar && !highlightColor && styles.dimmed,
-          isNavigating && {
-            ...styles.navigatingRow,
-            backgroundColor: withAlpha(theme.colors.tertiary, 0.3),
-          },
-        ]}
-      >
+        <View
+          style={[
+            styles.item,
+            isBranded && {
+              ...styles.brandedStripe,
+              borderLeftColor: theme.colors.primary,
+            },
+            !inBar && !highlightColor && styles.dimmed,
+            isNavigating && {
+              ...styles.navigatingRow,
+              backgroundColor: withAlpha(theme.colors.tertiary, 0.3),
+            },
+          ]}
+        >
+        {onToggleInBar && (
+          <Pressable
+            onPress={() => onToggleInBar(id)}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            android_ripple={{ ...ripple, borderless: true }}
+            style={({ pressed }) => [styles.leftCheck, pressed && styles.pressedCheck]}
+          >
+            <MaterialIcons
+              name={inBar ? 'check-box' : 'check-box-outline-blank'}
+              size={22}
+              color={inBar ? theme.colors.primary : theme.colors.onSurfaceVariant}
+            />
+          </Pressable>
+        )}
+
         {inShoppingList && !onToggleShoppingList && !onRemove && (
           <MaterialIcons
             name="shopping-cart"
@@ -185,19 +200,6 @@ function IngredientRow({
               color={theme.colors.error}
             />
           </Pressable>
-        ) : onToggleInBar ? (
-          <Pressable
-            onPress={() => onToggleInBar(id)}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            android_ripple={{ ...ripple, borderless: true }}
-            style={({ pressed }) => [styles.checkButton, pressed && styles.pressedCheck]}
-          >
-            <MaterialIcons
-              name={inBar ? 'check-circle' : 'radio-button-unchecked'}
-              size={22}
-              color={inBar ? theme.colors.primary : theme.colors.onSurfaceVariant}
-            />
-          </Pressable>
         ) : onToggleShoppingList ? (
           <Pressable
             onPress={() => onToggleShoppingList(id)}
@@ -265,6 +267,7 @@ const styles = StyleSheet.create({
   cartIcon: { position: 'absolute', bottom: 4, right: 60, zIndex: 1 },
   brandedStripe: { borderLeftWidth: 4, paddingLeft: 8 },
   checkButton: { marginLeft: 8, paddingVertical: 6, paddingHorizontal: 4 },
+  leftCheck: { marginRight: 8, paddingVertical: 6, paddingHorizontal: 4 },
   pressedCheck: { opacity: 0.7, transform: [{ scale: 0.92 }] },
   removeButton: { marginLeft: 8, paddingVertical: 6, paddingHorizontal: 4 },
   pressedRemove: { opacity: 0.7, transform: [{ scale: 0.92 }] },


### PR DESCRIPTION
## Summary
- show checkbox on left of ingredient rows to toggle availability
- persist availability changes when toggling ingredient in list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af17361d408326aa6a9d3cfa23a01f