### PR TITLE
feat: add my ingredients screen

### DIFF
--- a/app/(tabs)/ingredients/my.tsx
+++ b/app/(tabs)/ingredients/my.tsx
@@ -1,10 +1,99 @@
-import { ThemedView } from '@/components/ThemedView';
-import IngredientList from '@/components/IngredientList';
+import React, { useCallback, useState } from 'react';
+import {
+  View,
+  Text,
+  FlatList,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { useRouter, useFocusEffect } from 'expo-router';
+import {
+  getIngredientsInBar,
+  setIngredientInBar,
+  type Ingredient,
+} from '@/storage/ingredientsStorage';
+import IngredientRow from '@/components/IngredientRow';
 
 export default function MyIngredientsScreen() {
+  const [ingredients, setIngredients] = useState<Ingredient[]>([]);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useFocusEffect(
+    useCallback(() => {
+      let isActive = true;
+
+      const load = async () => {
+        setLoading(true);
+        const data = await getIngredientsInBar();
+        if (isActive) {
+          setIngredients(data);
+          setLoading(false);
+        }
+      };
+
+      load();
+
+      return () => {
+        isActive = false;
+      };
+    }, [])
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#4DABF7" />
+        <Text style={{ marginTop: 12 }}>Loading ingredients...</Text>
+      </View>
+    );
+  }
+
+  const toggleInBar = async (id: number) => {
+    const ingredient = ingredients.find((i) => i.id === id);
+    if (!ingredient) {
+      return;
+    }
+    const updated = !ingredient.inBar;
+    await setIngredientInBar(id, updated);
+    setIngredients((prev) =>
+      updated
+        ? prev.map((i) => (i.id === id ? { ...i, inBar: updated } : i))
+        : prev.filter((i) => i.id !== id)
+    );
+  };
+
+  const renderItem = ({ item }: { item: Ingredient }) => (
+    <IngredientRow
+      id={item.id}
+      name={item.name}
+      photoUri={item.photoUri}
+      tags={item.tags}
+      usageCount={0}
+      showMake={false}
+      inBar={item.inBar}
+      inShoppingList={item.inShoppingList}
+      baseIngredientId={item.baseIngredientId}
+      onPress={() => router.push(`/ingredient/${item.id}`)}
+      onToggleInBar={toggleInBar}
+    />
+  );
+
   return (
-    <ThemedView style={{ flex: 1 }}>
-      <IngredientList />
-    </ThemedView>
+    <FlatList
+      data={ingredients}
+      keyExtractor={(item) => item.id.toString()}
+      renderItem={renderItem}
+      ListFooterComponent={() => <View style={{ height: 80 }} />}
+    />
   );
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+

--- a/storage/ingredientsStorage.ts
+++ b/storage/ingredientsStorage.ts
@@ -97,6 +97,10 @@ export async function getBaseIngredients(): Promise<Ingredient[]> {
   return queryIngredients('WHERE baseIngredientId IS NULL');
 }
 
+export async function getIngredientsInBar(): Promise<Ingredient[]> {
+  return queryIngredients('WHERE inBar = 1');
+}
+
 export async function getIngredientById(id: number): Promise<Ingredient | null> {
   const rows = await db.getAllAsync<IngredientRow>(
     'SELECT * FROM ingredients WHERE id = ? LIMIT 1',


### PR DESCRIPTION
## Summary
- show user's bar ingredients with toggle support
- add DB query for in-bar ingredients

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af1d0156388326aa081966f7b621e2