### PR TITLE
Use theme color for top tab indicator

### DIFF
--- a/app/(tabs)/cocktails/_layout.tsx
+++ b/app/(tabs)/cocktails/_layout.tsx
@@ -15,7 +15,12 @@ export default function CocktailsLayout() {
   const router = useRouter();
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>
-      <Tabs screenOptions={{ tabBarStyle: { backgroundColor: colors.surface } }}>
+      <Tabs
+        screenOptions={{
+          tabBarStyle: { backgroundColor: colors.surface },
+          tabBarIndicatorStyle: { backgroundColor: colors.primary },
+        }}
+      >
         <Tabs.Screen name="all" options={{ title: 'All' }} />
         <Tabs.Screen name="my" options={{ title: 'My' }} />
         <Tabs.Screen name="favorites" options={{ title: 'Favorites' }} />

--- a/app/(tabs)/ingredients/_layout.tsx
+++ b/app/(tabs)/ingredients/_layout.tsx
@@ -16,7 +16,12 @@ export default function IngredientsLayout() {
   const router = useRouter();
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>
-      <Tabs screenOptions={{ tabBarStyle: { backgroundColor: colors.surface } }}>
+      <Tabs
+        screenOptions={{
+          tabBarStyle: { backgroundColor: colors.surface },
+          tabBarIndicatorStyle: { backgroundColor: colors.primary },
+        }}
+      >
         <Tabs.Screen name="all" options={{ title: 'All' }} />
         <Tabs.Screen name="my" options={{ title: 'My' }} />
         <Tabs.Screen name="shopping" options={{ title: 'Shopping' }} />


### PR DESCRIPTION
## Summary
- style cocktail top tabs to show indicator with theme's primary color
- style ingredient top tabs to show indicator with theme's primary color

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af206e81c08326b4b2bef21145124f