### PR TITLE
feat: add cocktail tag storage

### DIFF
--- a/constants/CocktailTags.ts
+++ b/constants/CocktailTags.ts
@@ -1,0 +1,17 @@
+import { TAG_COLORS } from './IngredientTags';
+import type { CocktailTag } from '@/storage/cocktailTagsStorage';
+
+export const COCKTAIL_TAGS: CocktailTag[] = [
+  { id: 1, name: 'IBA Official', color: TAG_COLORS[9], base: true },
+  { id: 2, name: 'Unforgettables', color: TAG_COLORS[3], base: true },
+  { id: 3, name: 'Contemporary', color: TAG_COLORS[5], base: true },
+  { id: 4, name: 'New Era', color: TAG_COLORS[7], base: true },
+  { id: 5, name: 'strong', color: TAG_COLORS[0], base: true },
+  { id: 6, name: 'moderate', color: TAG_COLORS[1], base: true },
+  { id: 7, name: 'soft', color: TAG_COLORS[12], base: true },
+  { id: 8, name: 'long', color: TAG_COLORS[13], base: true },
+  { id: 9, name: 'shooter', color: TAG_COLORS[14], base: true },
+  { id: 10, name: 'non-alcoholic', color: TAG_COLORS[11], base: true },
+  { id: 11, name: 'custom', color: TAG_COLORS[15], base: false },
+];
+

--- a/storage/cocktailTagsStorage.ts
+++ b/storage/cocktailTagsStorage.ts
@@ -1,0 +1,64 @@
+import { openDatabaseSync } from 'expo-sqlite';
+import { COCKTAIL_TAGS } from '@/constants/CocktailTags';
+
+export type CocktailTag = {
+  id: number;
+  name: string;
+  color: string;
+  base: boolean;
+};
+
+const db = openDatabaseSync('cocktails.db');
+
+db.execSync(
+  `CREATE TABLE IF NOT EXISTS cocktailTags (
+    id INTEGER PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    color TEXT NOT NULL,
+    base INTEGER NOT NULL
+  );`
+);
+
+void (async () => {
+  for (const tag of COCKTAIL_TAGS) {
+    await db.runAsync(
+      'INSERT OR IGNORE INTO cocktailTags (id, name, color, base) VALUES (?, ?, ?, ?)',
+      tag.id,
+      tag.name,
+      tag.color,
+      tag.base ? 1 : 0
+    );
+  }
+})();
+
+type CocktailTagRow = {
+  id: number;
+  name: string;
+  color: string;
+  base: number;
+};
+
+function mapRow(row: CocktailTagRow): CocktailTag {
+  return {
+    id: row.id,
+    name: row.name,
+    color: row.color,
+    base: row.base === 1,
+  };
+}
+
+export async function getAllTags(): Promise<CocktailTag[]> {
+  const rows = await db.getAllAsync<CocktailTagRow>('SELECT * FROM cocktailTags');
+  return rows.map(mapRow);
+}
+
+export async function addTag(tag: CocktailTag): Promise<void> {
+  await db.runAsync(
+    'INSERT INTO cocktailTags (id, name, color, base) VALUES (?, ?, ?, ?)',
+    tag.id,
+    tag.name,
+    tag.color,
+    tag.base ? 1 : 0
+  );
+}
+


### PR DESCRIPTION
## Summary
- add cocktail tag constants
- create cocktailTags SQLite table with seeding

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af35599fd48326bedf3fd4e8932a67