### PR TITLE
Add glassware table and seed data

### DIFF
--- a/constants/Glassware.ts
+++ b/constants/Glassware.ts
@@ -1,0 +1,33 @@
+import type { Glassware } from '@/storage/glasswareStorage';
+
+export const GLASSWARE: Glassware[] = [
+  { id: 'bowl', name: 'Bowl', imagePath: 'assets/glassware/bowl.jpg' },
+  { id: 'champagne_flute', name: 'Champagne Flute', imagePath: 'assets/glassware/champagne.jpg' },
+  { id: 'cocktail_glass', name: 'Cocktail glass', imagePath: 'assets/glassware/cocktail.jpg' },
+  { id: 'collins_glass', name: 'Collins glass', imagePath: 'assets/glassware/collins.jpg' },
+  { id: 'copper_mug', name: 'Copper mug', imagePath: 'assets/glassware/copper.jpg' },
+  { id: 'coupe', name: 'Coupe', imagePath: 'assets/glassware/coupe.jpg' },
+  { id: 'cup', name: 'Cup', imagePath: 'assets/glassware/cup.jpg' },
+  { id: 'goblet', name: 'Goblet', imagePath: 'assets/glassware/goblet.jpg' },
+  { id: 'highball_glass', name: 'Highball glass', imagePath: 'assets/glassware/highball.jpg' },
+  { id: 'hurricane_glass', name: 'Hurricane glass', imagePath: 'assets/glassware/hurricane.jpg' },
+  { id: 'irish_coffee_glass', name: 'Irish Coffee glass', imagePath: 'assets/glassware/irish.jpg' },
+  { id: 'margarita_glass', name: 'Margarita glass', imagePath: 'assets/glassware/margarita.jpg' },
+  { id: 'nick_and_nora', name: 'Nick and Nora', imagePath: 'assets/glassware/nick.jpg' },
+  { id: 'pitcher', name: 'Pitcher', imagePath: 'assets/glassware/pitcher.jpg' },
+  { id: 'pub_glass', name: 'Pub glass', imagePath: 'assets/glassware/pub.jpg' },
+  { id: 'rocks_glass', name: 'Rocks glass', imagePath: 'assets/glassware/rocks.jpg' },
+  { id: 'shooter', name: 'Shooter', imagePath: 'assets/glassware/shooter.jpg' },
+  { id: 'snifter', name: 'Snifter', imagePath: 'assets/glassware/snifter.jpg' },
+  { id: 'tiki', name: 'Tiki', imagePath: 'assets/glassware/tiki.jpg' },
+  { id: 'wine_glass', name: 'Wine glass', imagePath: 'assets/glassware/wine.jpg' },
+];
+
+export const getGlassById = (id: string): Glassware | null =>
+  GLASSWARE.find((g) => g.id === id) ?? null;
+
+export const searchGlass = (q: string): Glassware[] => {
+  const s = q.trim().toLowerCase();
+  if (!s) return GLASSWARE;
+  return GLASSWARE.filter((g) => g.name.toLowerCase().includes(s));
+};

--- a/storage/glasswareStorage.ts
+++ b/storage/glasswareStorage.ts
@@ -1,0 +1,48 @@
+import { openDatabaseSync } from 'expo-sqlite';
+import { GLASSWARE } from '@/constants/Glassware';
+
+export type Glassware = {
+  id: string;
+  name: string;
+  imagePath: string;
+};
+
+const db = openDatabaseSync('cocktails.db');
+
+db.execSync(
+  `CREATE TABLE IF NOT EXISTS glassware (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    image_path TEXT NOT NULL
+  );`
+);
+
+void (async () => {
+  for (const glass of GLASSWARE) {
+    await db.runAsync(
+      'INSERT OR IGNORE INTO glassware (id, name, image_path) VALUES (?, ?, ?)',
+      glass.id,
+      glass.name,
+      glass.imagePath
+    );
+  }
+})();
+
+type GlasswareRow = {
+  id: string;
+  name: string;
+  image_path: string;
+};
+
+function mapRow(row: GlasswareRow): Glassware {
+  return {
+    id: row.id,
+    name: row.name,
+    imagePath: row.image_path,
+  };
+}
+
+export async function getAllGlassware(): Promise<Glassware[]> {
+  const rows = await db.getAllAsync<GlasswareRow>('SELECT * FROM glassware');
+  return rows.map(mapRow);
+}


### PR DESCRIPTION
## Summary
- add GLASSWARE constant with id, name, image path and helper lookup utilities
- create SQLite storage to initialize `glassware` table and seed with data

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af3813931c8326977dfd120d515172