### PR TITLE
Seed database with initial cocktail and ingredient data

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,8 +5,10 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { PaperProvider } from 'react-native-paper';
+import { useEffect } from 'react';
 
 import { AppTheme } from '@/constants/AppTheme';
+import { initializeDatabase } from '@/utils/initializeDatabase';
 
 const NavigationTheme = {
   ...DefaultTheme,
@@ -21,6 +23,10 @@ export default function RootLayout() {
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
+
+  useEffect(() => {
+    void initializeDatabase();
+  }, []);
 
   if (!loaded) {
     // Async font loading only occurs in development.

--- a/storage/cocktailsStorage.ts
+++ b/storage/cocktailsStorage.ts
@@ -1,0 +1,95 @@
+import { openDatabaseSync } from 'expo-sqlite';
+import type { CocktailTag } from './cocktailTagsStorage';
+
+export type CocktailIngredient = {
+  order: number;
+  ingredientId: number;
+  amount?: string;
+  unitId?: number;
+  garnish: boolean;
+  optional: boolean;
+  allowBaseSubstitution: boolean;
+  allowBrandedSubstitutes: boolean;
+  substitutes: number[];
+};
+
+export type Cocktail = {
+  id: number;
+  name: string;
+  glassId: string;
+  tags: CocktailTag[];
+  description: string;
+  instructions: string;
+  ingredients: CocktailIngredient[];
+  createdAt: number;
+  updatedAt: number;
+  photoUri?: string | null;
+};
+
+const db = openDatabaseSync('cocktails.db');
+
+db.execSync(
+  `CREATE TABLE IF NOT EXISTS cocktails (
+    id INTEGER PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    glassId TEXT,
+    tags TEXT,
+    description TEXT,
+    instructions TEXT,
+    ingredients TEXT,
+    createdAt INTEGER,
+    updatedAt INTEGER,
+    photoUri TEXT
+  );`
+);
+
+type CocktailRow = {
+  id: number;
+  name: string;
+  glassId: string | null;
+  tags: string | null;
+  description: string | null;
+  instructions: string | null;
+  ingredients: string | null;
+  createdAt: number | null;
+  updatedAt: number | null;
+  photoUri: string | null;
+};
+
+function mapRow(row: CocktailRow): Cocktail {
+  return {
+    id: row.id,
+    name: row.name,
+    glassId: row.glassId ?? '',
+    tags: row.tags ? (JSON.parse(row.tags) as CocktailTag[]) : [],
+    description: row.description ?? '',
+    instructions: row.instructions ?? '',
+    ingredients: row.ingredients
+      ? (JSON.parse(row.ingredients) as CocktailIngredient[])
+      : [],
+    createdAt: row.createdAt ?? Date.now(),
+    updatedAt: row.updatedAt ?? Date.now(),
+    photoUri: row.photoUri ?? undefined,
+  };
+}
+
+export async function addCocktail(cocktail: Cocktail): Promise<void> {
+  await db.runAsync(
+    'INSERT INTO cocktails (id, name, glassId, tags, description, instructions, ingredients, createdAt, updatedAt, photoUri) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    cocktail.id,
+    cocktail.name,
+    cocktail.glassId,
+    JSON.stringify(cocktail.tags),
+    cocktail.description,
+    cocktail.instructions,
+    JSON.stringify(cocktail.ingredients),
+    cocktail.createdAt,
+    cocktail.updatedAt,
+    cocktail.photoUri ?? null
+  );
+}
+
+export async function getAllCocktails(): Promise<Cocktail[]> {
+  const rows = await db.getAllAsync<CocktailRow>('SELECT * FROM cocktails');
+  return rows.map(mapRow);
+}

--- a/utils/initializeDatabase.ts
+++ b/utils/initializeDatabase.ts
@@ -1,0 +1,80 @@
+import data from '@/assets/data/data.json';
+import { addIngredient, getAllIngredients, type Ingredient } from '@/storage/ingredientsStorage';
+import { addCocktail, getAllCocktails, type Cocktail, type CocktailIngredient } from '@/storage/cocktailsStorage';
+import { addCocktailIngredient } from '@/storage/cocktailIngredientsStorage';
+
+// Ensure static tables are populated
+import '@/storage/ingredientTagsStorage';
+import '@/storage/cocktailTagsStorage';
+import '@/storage/glasswareStorage';
+import '@/storage/measureUnitsStorage';
+
+export async function initializeDatabase(): Promise<void> {
+  const [existingIngredients, existingCocktails] = await Promise.all([
+    getAllIngredients(),
+    getAllCocktails(),
+  ]);
+
+  if (existingIngredients.length > 0 || existingCocktails.length > 0) {
+    return;
+  }
+
+  // Map original ingredient IDs to numeric IDs for SQLite
+  const ingredientIdMap = new Map<string, number>();
+  data.ingredients.forEach((ing, index) => {
+    ingredientIdMap.set(String(ing.id), index + 1);
+  });
+
+  // Insert ingredients
+  for (const ing of data.ingredients) {
+    const newId = ingredientIdMap.get(String(ing.id))!;
+    const baseId = ing.baseIngredientId
+      ? ingredientIdMap.get(String(ing.baseIngredientId))
+      : undefined;
+
+    await addIngredient({
+      id: newId,
+      name: ing.name,
+      description: ing.description,
+      photoUri: ing.photoUri ?? undefined,
+      tags: ing.tags,
+      baseIngredientId: baseId,
+      inBar: false,
+      inShoppingList: false,
+    } as Ingredient);
+  }
+
+  // Insert cocktails
+  for (const cocktail of data.cocktails) {
+    const ingredients: CocktailIngredient[] = cocktail.ingredients.map((ci: any) => ({
+      order: ci.order,
+      ingredientId: ingredientIdMap.get(String(ci.ingredientId))!,
+      amount: ci.amount,
+      unitId: ci.unitId,
+      garnish: ci.garnish,
+      optional: ci.optional,
+      allowBaseSubstitution: ci.allowBaseSubstitution,
+      allowBrandedSubstitutes: ci.allowBrandedSubstitutes,
+      substitutes: ci.substitutes
+        .map((s: string) => ingredientIdMap.get(String(s))!)
+        .filter(Boolean),
+    }));
+
+    await addCocktail({
+      id: cocktail.id,
+      name: cocktail.name,
+      glassId: cocktail.glassId,
+      tags: cocktail.tags,
+      description: cocktail.description,
+      instructions: cocktail.instructions,
+      ingredients,
+      createdAt: cocktail.createdAt,
+      updatedAt: cocktail.updatedAt,
+      photoUri: cocktail.photoUri ?? null,
+    } as Cocktail);
+
+    for (const ci of ingredients) {
+      await addCocktailIngredient(cocktail.id, ci.ingredientId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add SQLite storage for cocktails with tags and ingredient details
- populate cocktails and ingredients from bundled JSON when DB is empty
- initialize data import on app startup

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npx tsc --noEmit` (fails: Property 'placeholder' does not exist on type 'MD3Colors')

------
https://chatgpt.com/codex/tasks/task_e_68af3d1779b48326ac88db5eef06ec82