### PR TITLE
Show message for empty ingredient lists

### DIFF
--- a/app/(tabs)/ingredients/my.tsx
+++ b/app/(tabs)/ingredients/my.tsx
@@ -42,7 +42,7 @@ export default function MyIngredientsScreen() {
 
   if (loading) {
     return (
-      <View style={styles.loadingContainer}>
+      <View style={styles.centerContent}>
         <ActivityIndicator size="large" color="#4DABF7" />
         <Text style={{ marginTop: 12 }}>Loading ingredients...</Text>
       </View>
@@ -84,13 +84,18 @@ export default function MyIngredientsScreen() {
       data={ingredients}
       keyExtractor={(item) => item.id.toString()}
       renderItem={renderItem}
+      ListEmptyComponent={() => (
+        <View style={styles.centerContent}>
+          <Text>Your bar is empty.</Text>
+        </View>
+      )}
       ListFooterComponent={() => <View style={{ height: 80 }} />}
     />
   );
 }
 
 const styles = StyleSheet.create({
-  loadingContainer: {
+  centerContent: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',

--- a/app/(tabs)/ingredients/shopping.tsx
+++ b/app/(tabs)/ingredients/shopping.tsx
@@ -41,7 +41,7 @@ export default function ShoppingIngredientsScreen() {
 
   if (loading) {
     return (
-      <View style={styles.loadingContainer}>
+      <View style={styles.centerContent}>
         <ActivityIndicator size="large" color="#4DABF7" />
         <Text style={{ marginTop: 12 }}>Loading ingredients...</Text>
       </View>
@@ -70,7 +70,7 @@ export default function ShoppingIngredientsScreen() {
       keyExtractor={(item) => item.id.toString()}
       renderItem={renderItem}
       ListEmptyComponent={() => (
-        <View style={styles.loadingContainer}>
+        <View style={styles.centerContent}>
           <Text>Your shopping list is empty.</Text>
         </View>
       )}
@@ -80,7 +80,7 @@ export default function ShoppingIngredientsScreen() {
 }
 
 const styles = StyleSheet.create({
-  loadingContainer: {
+  centerContent: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- display a placeholder when the bar has no ingredients
- keep shopping list screen consistent by centering its empty state message

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af40ceba208326bf7974b204b0e858