### PR TITLE
Load ingredient images from local assets

### DIFF
--- a/app/add-ingredient.tsx
+++ b/app/add-ingredient.tsx
@@ -18,6 +18,7 @@ import ConfirmDialog from '@/components/ConfirmDialog';
 import IngredientHeader from '@/components/IngredientHeader';
 import { Stack, useRouter } from 'expo-router';
 import { useTheme } from 'react-native-paper';
+import { getImageSource } from '../utils/getImageSource';
 
 import {
   addIngredient,
@@ -145,7 +146,7 @@ export default function AddIngredientScreen() {
         >
           {photoUri ? (
             <Image
-              source={{ uri: photoUri }}
+              source={getImageSource(photoUri)}
               style={styles.image}
               resizeMode="contain"
             />
@@ -204,7 +205,7 @@ export default function AddIngredientScreen() {
             <View style={styles.baseFieldContent}>
               {baseIngredient.photoUri ? (
                 <Image
-                  source={{ uri: baseIngredient.photoUri }}
+                  source={getImageSource(baseIngredient.photoUri)}
                   style={styles.baseFieldImage}
                 />
               ) : (
@@ -324,7 +325,7 @@ export default function AddIngredientScreen() {
                         }}
                       >
                         {b.photoUri ? (
-                          <Image source={{ uri: b.photoUri }} style={styles.baseImage} />
+                          <Image source={getImageSource(b.photoUri)} style={styles.baseImage} />
                         ) : (
                           <View
                             style={[

--- a/app/edit-ingredient.tsx
+++ b/app/edit-ingredient.tsx
@@ -18,6 +18,7 @@ import ConfirmDialog from '@/components/ConfirmDialog';
 import IngredientHeader from '@/components/IngredientHeader';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTheme } from 'react-native-paper';
+import { getImageSource } from '../utils/getImageSource';
 
 import {
   deleteIngredient,
@@ -197,7 +198,7 @@ export default function EditIngredientScreen() {
             onPress={pickImage}
           >
             {photoUri ? (
-              <Image source={{ uri: photoUri }} style={styles.image} />
+              <Image source={getImageSource(photoUri)} style={styles.image} />
             ) : (
               <Text
                 style={[styles.imagePlaceholder, { color: theme.colors.onSurfaceVariant }]}
@@ -253,7 +254,7 @@ export default function EditIngredientScreen() {
               <View style={styles.baseFieldContent}>
                 {baseIngredient.photoUri ? (
                   <Image
-                    source={{ uri: baseIngredient.photoUri }}
+                    source={getImageSource(baseIngredient.photoUri)}
                     style={styles.baseFieldImage}
                     resizeMode="contain"
                   />
@@ -351,7 +352,7 @@ export default function EditIngredientScreen() {
                         }}
                       >
                         {b.photoUri ? (
-                          <Image source={{ uri: b.photoUri }} style={styles.baseImage} />
+                          <Image source={getImageSource(b.photoUri)} style={styles.baseImage} />
                         ) : (
                           <View
                             style={[

--- a/app/ingredient/[id].tsx
+++ b/app/ingredient/[id].tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-native';
 import { useTheme } from 'react-native-paper';
 import { MaterialIcons } from '@expo/vector-icons';
+import { getImageSource } from '../../utils/getImageSource';
 
 import IngredientHeader from '@/components/IngredientHeader';
 import ConfirmDialog from '@/components/ConfirmDialog';
@@ -130,7 +131,7 @@ export default function IngredientViewScreen() {
         <Text style={[styles.name, { color: theme.colors.onSurface }]}>Ingredient details</Text>
         {ingredient.photoUri ? (
           <Image
-            source={{ uri: ingredient.photoUri }}
+            source={getImageSource(ingredient.photoUri)}
             style={styles.image}
             resizeMode="contain"
           />
@@ -191,7 +192,7 @@ export default function IngredientViewScreen() {
               <View style={styles.baseContainer}>
                 {baseIngredient.photoUri ? (
                   <Image
-                    source={{ uri: baseIngredient.photoUri }}
+                    source={getImageSource(baseIngredient.photoUri)}
                     style={styles.baseImage}
                     resizeMode="contain"
                   />
@@ -249,7 +250,7 @@ export default function IngredientViewScreen() {
                   <View style={styles.baseContainer}>
                     {b.photoUri ? (
                       <Image
-                        source={{ uri: b.photoUri }}
+                        source={getImageSource(b.photoUri)}
                         style={styles.baseImage}
                         resizeMode="contain"
                       />

--- a/components/IngredientRow.tsx
+++ b/components/IngredientRow.tsx
@@ -3,6 +3,7 @@ import { View, Text, Image, Pressable, StyleSheet, Platform } from 'react-native
 import { useTheme } from 'react-native-paper';
 import { MaterialIcons } from '@expo/vector-icons';
 import { withAlpha } from '../utils/color';
+import { getImageSource } from '../utils/getImageSource';
 
 export const IMAGE_SIZE = 50;
 const ROW_VERTICAL = 8;
@@ -99,7 +100,7 @@ function IngredientRow({
         >
           {photoUri ? (
             <Image
-              source={{ uri: photoUri }}
+              source={getImageSource(photoUri)}
               style={[styles.image, { backgroundColor: theme.colors.background }]}
               resizeMode="contain"
             />

--- a/utils/getImageSource.ts
+++ b/utils/getImageSource.ts
@@ -1,0 +1,9 @@
+import { ImageSourcePropType } from 'react-native';
+import assetMap from '../assets/assetMap';
+
+export function getImageSource(photoUri?: string | null): ImageSourcePropType | undefined {
+  if (!photoUri) {
+    return undefined;
+  }
+  return assetMap[photoUri] ?? { uri: photoUri };
+}


### PR DESCRIPTION
## Summary
- add helper to resolve photo URIs via asset map or remote URL
- use helper across ingredient components to display local images

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af63a01788832689058b57373facca