### PR TITLE
Show cocktail usage info in ingredient lists

### DIFF
--- a/components/IngredientRow.tsx
+++ b/components/IngredientRow.tsx
@@ -132,11 +132,11 @@ function IngredientRow({
               {usageCount > 0
                 ? usageCount === 1
                   ? showMake
-                    ? `Make ${singleCocktailName || '1 cocktail'}`
-                    : singleCocktailName || '1 cocktail'
+                    ? `Make ${singleCocktailName || '1 cocktail'} with it`
+                    : `Used in ${singleCocktailName || '1 cocktail'}`
                   : showMake
-                  ? `Make ${usageCount} cocktails`
-                  : `${usageCount} cocktails`
+                  ? `Make ${usageCount} cocktails with it`
+                  : `Used in ${usageCount} cocktails`
                 : '\u00A0'}
             </Text>
           </View>

--- a/utils/ingredientUsage.ts
+++ b/utils/ingredientUsage.ts
@@ -1,0 +1,38 @@
+import type { Cocktail } from '@/storage/cocktailsStorage';
+
+export type IngredientUsage = {
+  count: number;
+  singleName?: string;
+};
+
+export function calculateIngredientUsage(
+  cocktails: Cocktail[],
+  barIds?: Set<number>
+): Record<number, IngredientUsage> {
+  const usage: Record<number, IngredientUsage> = {};
+  for (const cocktail of cocktails) {
+    if (barIds) {
+      const requiredIds = cocktail.ingredients
+        .filter((ci) => !ci.optional)
+        .map((ci) => ci.ingredientId);
+      const canMake = requiredIds.every((id) => barIds.has(id));
+      if (!canMake) {
+        continue;
+      }
+    }
+    for (const ci of cocktail.ingredients) {
+      if (barIds && !barIds.has(ci.ingredientId)) {
+        continue;
+      }
+      const info = usage[ci.ingredientId] || { count: 0 };
+      info.count += 1;
+      if (info.count === 1) {
+        info.singleName = cocktail.name;
+      } else {
+        delete info.singleName;
+      }
+      usage[ci.ingredientId] = info;
+    }
+  }
+  return usage;
+}


### PR DESCRIPTION
## Summary
- show number of cocktails each ingredient appears in for All and Shopping lists
- display makeable cocktail counts for My list
- add utility to calculate ingredient usage across cocktails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af69131c6c8326b09d5249587cc2fa